### PR TITLE
fixed bug where all levels were skipped if skip levels are null

### DIFF
--- a/src/java/org/chai/kevin/location/CalculationEntity.java
+++ b/src/java/org/chai/kevin/location/CalculationEntity.java
@@ -81,12 +81,10 @@ public abstract class CalculationEntity {
 			result = result | child.collectLocations(locations, dataLocations, dataEntityTypes, skips);
 		}
 	
-		if (!result) {
-			List<DataLocationEntity> dataEntities = getDataEntities(skips, dataEntityTypes);
-			if (!dataEntities.isEmpty()) {
-				result = true;
-				if (dataLocations != null) dataLocations.addAll(dataEntities);
-			}
+		List<DataLocationEntity> dataEntities = getDataEntities(skips, dataEntityTypes);
+		if (!dataEntities.isEmpty()) {
+			result = true;
+			if (dataLocations != null) dataLocations.addAll(dataEntities);
 		}
 		
 		if (result && locations != null) locations.add((LocationEntity) this);

--- a/src/java/org/chai/kevin/location/LocationEntity.java
+++ b/src/java/org/chai/kevin/location/LocationEntity.java
@@ -73,7 +73,7 @@ public class LocationEntity extends CalculationEntity {
 		}		
 		
 		for (LocationEntity child : children) {
-			if (skipLevels == null || skipLevels.contains(child.getLevel())) {
+			if (skipLevels != null && skipLevels.contains(child.getLevel())) {
 				result.addAll(child.getDataEntities(skipLevels, types));
 			}
 		}

--- a/test/integration/org/chai/kevin/survey/SummaryServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/survey/SummaryServiceSpec.groovy
@@ -1,6 +1,7 @@
 package org.chai.kevin.survey;
 
 import org.chai.kevin.data.Type;
+import org.chai.kevin.location.DataEntityType;
 import org.chai.kevin.location.DataLocationEntity;
 import org.chai.kevin.location.LocationEntity;
 import org.chai.kevin.survey.summary.SurveySummaryPage;
@@ -98,6 +99,21 @@ class SummaryServiceSpec extends SurveyIntegrationTests {
 		then:
 		questionSummary.questions == 0
 		questionSummary.completedQuestions == 1
+	}
+	
+	def "test locations are collected at all levels"() {
+		setupLocationTree()
+		def north = LocationEntity.findByCode(NORTH)
+		newDataLocationEntity(j(["en":'DP']), "DP", north, DataEntityType.findByCode(DISTRICT_HOSPITAL_GROUP));
+		def period = newPeriod()
+		def survey = newSurvey(period)
+		
+		when:
+		def summaryPage = summaryService.getSurveySummaryPage(LocationEntity.findByCode(RWANDA), survey)
+		
+		then:
+		s(summaryPage.facilities*.code).equals(s([BUTARO, KIVUYE, "DP"]))
+		
 	}
 	
 }

--- a/test/unit/org/chai/kevin/location/CalculationEntityUnitSpec.groovy
+++ b/test/unit/org/chai/kevin/location/CalculationEntityUnitSpec.groovy
@@ -2,8 +2,54 @@ package org.chai.kevin.location
 
 import grails.plugin.spock.UnitSpec;
 
-class CalculationEntitySpec extends UnitSpec {
+class CalculationEntityUnitSpec extends UnitSpec {
 
+	def "get data entities on location entity"() {
+		when:
+		def rwanda = new LocationEntity(code: "rwanda")
+		def north = new LocationEntity(code: "north", parent: rwanda)
+		def burera = new LocationEntity(code: "burera", parent: north)
+		rwanda.children = [north]
+		north.children = [burera]
+		
+		def data1 = new DataLocationEntity(code: 'data1', location: north);
+		north.dataEntities = [data1]
+		def data2 = new DataLocationEntity(code: 'data2', location: burera);
+		burera.dataEntities = [data2]
+		
+		then:
+		rwanda.getDataEntities().empty
+		rwanda.getDataEntities(null, null).empty
+		north.getDataEntities().equals([data1])
+		north.getDataEntities(null, null).equals([data1])
+		burera.getDataEntities().equals([data2])
+		burera.getDataEntities(null, null).equals([data2])
+	}
+
+	def "get data entities on location entity with skip"() {
+		setup:
+		def country = new LocationLevel(code: "country")
+		def province = new LocationLevel(code: "province")
+		def district = new LocationLevel(code: "district")
+		
+		when:
+		def rwanda = new LocationEntity(code: "rwanda", level: country)
+		def north = new LocationEntity(code: "north", parent: rwanda, level: province)
+		def burera = new LocationEntity(code: "burera", parent: north, level: district)
+		rwanda.children = [north]
+		north.children = [burera]
+		
+		def data1 = new DataLocationEntity(code: 'data1', location: north);
+		north.dataEntities = [data1]
+		def data2 = new DataLocationEntity(code: 'data2', location: burera);
+		burera.dataEntities = [data2]
+		
+		then:
+		rwanda.getDataEntities(new HashSet([province]), null).equals([data1])
+		rwanda.getDataEntities(new HashSet([province,district]), null).equals([data1, data2])
+		north.getDataEntities(new HashSet([district]), null).equals([data1, data2])
+	}
+		
 	def "collect data entities on location entity with specific type"() {
 		when:
 		def rwanda = new LocationEntity(code: "rwanda")
@@ -33,6 +79,24 @@ class CalculationEntitySpec extends UnitSpec {
 		then:
 		rwanda.collectTreeWithDataEntities(new HashSet([type2]), null).empty
 		rwanda.collectDataLocationEntities(new HashSet([type2]), null).empty
+		
+	}
+	
+	def "collect data entities on location at different levels"() {
+		when:
+		def rwanda = new LocationEntity(code: "rwanda")
+		def north = new LocationEntity(code: "north", parent: rwanda)
+		def burera = new LocationEntity(code: "burera", parent: north)
+		rwanda.children = [north]
+		north.children = [burera]
+		
+		def data1 = new DataLocationEntity(code: 'data1', location: north);
+		north.dataEntities = [data1]
+		def data2 = new DataLocationEntity(code: 'data2', location: burera);
+		burera.dataEntities = [data2]
+		
+		then:
+		rwanda.collectDataLocationEntities(null, null).equals([data2, data1])
 	}
 	
 	def "collect data entities for on data location entity"() {


### PR DESCRIPTION
This caused the data location entities attached to non-leaf locations to not show up in the summary survey tree.
