### PR TITLE
Links created with createLinkWithTargetURI now don't contain form params any more

### DIFF
--- a/grails-app/taglib/org/chai/kevin/UtilTagLib.groovy
+++ b/grails-app/taglib/org/chai/kevin/UtilTagLib.groovy
@@ -38,7 +38,7 @@ class UtilTagLib {
 	def createLinkWithTargetURI = {attrs, body ->
 		if (attrs['params'] == null) attrs['params'] = [:]
 		else attrs['params'] = new HashMap(attrs['params'])
-		attrs['params'] << [targetURI: createLink(controller: controllerName, action: actionName, params: params) - request.contextPath];
+		attrs['params'] << [targetURI: request.forwardURI - request.contextPath + '?' + request.queryString];
 		
 		log.debug('creating link with attrs: '+attrs)
 		out << createLink(attrs, body)

--- a/test/integration/org/chai/kevin/UtilTagLibTests.groovy
+++ b/test/integration/org/chai/kevin/UtilTagLibTests.groovy
@@ -1,0 +1,29 @@
+package org.chai.kevin
+
+import org.chai.kevin.security.UserController;
+
+import grails.test.GroovyPagesTestCase;
+
+class UtilTagLibTests extends GroovyPagesTestCase {
+
+	def grailsApplication
+	
+	def testLinkWithTargetURI() {
+		def controller = new UserController()
+		
+		// we assume that the query string is what's after '?'
+		controller.request.queryString = 'test=123'
+		// we assume that forwardURI is always the full URI after the hostname
+		controller.request.forwardURI = '/kevin/test/test'
+		// contextPath is always the path to the app
+		controller.request.contextPath = '/kevin'
+		controller.request.params = ['param': '123']
+		
+		def url = applyTemplate(
+			'<g:createLinkWithTargetURI controller="test" action="test" params="[test: 123]"/>'
+		)
+
+		assertEquals "/kevin/test/test?targetURI=%2Ftest%2Ftest%3Ftest%3D123&test=123", url
+	}
+	
+}


### PR DESCRIPTION
- tested on diverse pages
- wrote an integration tests that respect grails/http convention for request params
