### PR TITLE
Simplified survey controllers and gsps in view of admin planning tool

### DIFF
--- a/grails-app/controllers/org/chai/kevin/data/EnumOptionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/data/EnumOptionController.groovy
@@ -49,10 +49,7 @@ class EnumOptionController extends AbstractEntityController {
 	}
 	
 	def createEntity(){  
-		def entity = new EnumOption();
-		//FIXME find a better to do this
-		if (params['enumId']) entity.enume = Enum.get(params.int('enumId'))
-		return entity;
+		return new EnumOption();
 	}
 	
 	def getLabel() {
@@ -91,7 +88,7 @@ class EnumOptionController extends AbstractEntityController {
 	def list = {
 		adaptParamsForList();
 		
-		Enum enume = Enum.get(params.int('enumId'));
+		Enum enume = Enum.get(params.int('enume.id'));
 		
 		List<EnumOption> options = enume.enumOptions;
 		Collections.sort(options, Ordering.getOrderableComparator(languageService.currentLanguage, languageService.fallbackLanguage))
@@ -103,7 +100,6 @@ class EnumOptionController extends AbstractEntityController {
 			template: "data/enumOptionList",
 			entityCount: options.size(),
 			code: getLabel(),
-			enumeId: enume.id
 		])
 	}
 		

--- a/grails-app/controllers/org/chai/kevin/survey/CheckboxOptionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/CheckboxOptionController.groovy
@@ -47,10 +47,7 @@ class CheckboxOptionController extends AbstractEntityController {
 	}
 	
 	def createEntity() {
-		def entity = new SurveyCheckboxOption();
-		//FIXME find a better to do this
-		if (!params['question']) entity.question = SurveyCheckboxQuestion.get(params.questionId)
-		return entity
+		return new SurveyCheckboxOption();
 	}
 	
 	def getLabel() {

--- a/grails-app/controllers/org/chai/kevin/survey/CheckboxQuestionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/CheckboxQuestionController.groovy
@@ -49,10 +49,7 @@ class CheckboxQuestionController extends AbstractEntityController {
 		return SurveyCheckboxQuestion.get(id)
 	}
 	def createEntity() {
-		def entity = new SurveyCheckboxQuestion();
-		//FIXME find a better to do this
-		if (!params['sectionId.id']) entity.section = SurveySection.get(params.sectionId)
-		return entity
+		return new SurveyCheckboxQuestion();
 	}
 	
 	def getLabel() {

--- a/grails-app/controllers/org/chai/kevin/survey/ObjectiveController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/ObjectiveController.groovy
@@ -45,9 +45,7 @@ class ObjectiveController extends AbstractEntityController {
 	}
 	
 	def createEntity() {
-		def entity = new SurveyObjective()
-		if (!params['surveyId.id']) entity.survey = Survey.get(params.surveyId)
-		return entity;
+		return new SurveyObjective()
 	}
 
 	def getLabel() {
@@ -76,7 +74,7 @@ class ObjectiveController extends AbstractEntityController {
 	def list = {
 		adaptParamsForList()
 
-		Survey survey = Survey.get(params.surveyId);
+		Survey survey = Survey.get(params.int('survey.id'));
 		List<SurveyObjective> objectives = survey.objectives;
 		Collections.sort(objectives)
 		

--- a/grails-app/controllers/org/chai/kevin/survey/QuestionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/QuestionController.groovy
@@ -47,7 +47,7 @@ class QuestionController extends AbstractController {
 	def search = {
 		adaptParamsForList()
 		
-		Survey survey = Survey.get(params.int('surveyId'))
+		Survey survey = Survey.get(params.int('survey'))
 		List<SurveyQuestion> questions = surveyService.searchSurveyQuestions(params['q'], survey, params);
 		
 		render (view: '/survey/admin/list', model:[
@@ -63,7 +63,7 @@ class QuestionController extends AbstractController {
 	def list = {
 		adaptParamsForList()
 		
-		SurveySection section = SurveySection.get(params.int('sectionId'))
+		SurveySection section = SurveySection.get(params.int('section.id'))
 		List<SurveyQuestion> questions = section.questions;
 		Collections.sort(questions)
 		
@@ -83,15 +83,15 @@ class QuestionController extends AbstractController {
 	
 	
 	def getAjaxData = {
-		Survey survey = Survey.get(params.int('surveyId'));
+		Survey survey = Survey.get(params.int('survey'));
 		Set<SurveyQuestion> surveyQuestions = surveyService.searchSurveyQuestions(params['term'], survey);
 
 		render(contentType:"text/json") {
-			questions = array {
+			elements = array {
 				surveyQuestions.each { question ->
 					quest (
-						id: question.id,
-						question: Utils.stripHtml(g.i18n(field: question.names).toString(), 35)+' - '+ g.i18n(field: question.section.names)
+						key: question.id,
+						value: Utils.stripHtml(g.i18n(field: question.names).toString(), 35)+' - '+ g.i18n(field: question.section.names)
 					)
 				}
 			}

--- a/grails-app/controllers/org/chai/kevin/survey/SectionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/SectionController.groovy
@@ -43,10 +43,7 @@ class SectionController extends AbstractEntityController {
 	}
 	
 	def createEntity() {
-		def entity = new SurveySection()
-		//FIXME find a better to do this
-		if (!params['objectiveId.id']) entity.objective = SurveyObjective.get(params.objectiveId)
-		return entity
+		return new SurveySection()
 	}
 
 	def getTemplate() {
@@ -77,7 +74,7 @@ class SectionController extends AbstractEntityController {
 	def list = {
 		adaptParamsForList()
 		
-		SurveyObjective objective = SurveyObjective.get(params.objectiveId)
+		SurveyObjective objective = SurveyObjective.get(params.int('objective.id'))
 		List<SurveySection> sections = objective.sections;
 		Collections.sort(sections)
 

--- a/grails-app/controllers/org/chai/kevin/survey/SimpleQuestionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/SimpleQuestionController.groovy
@@ -51,10 +51,7 @@ class SimpleQuestionController extends AbstractEntityController {
 	}
 	
 	def createEntity() {
-		def entity = new SurveySimpleQuestion();
-		//FIXME find a better to do this
-		if (!params['sectionId.id']) entity.section = SurveySection.get(params.sectionId)
-		return entity
+		return new SurveySimpleQuestion();
 	}
 
 	def getLabel() {

--- a/grails-app/controllers/org/chai/kevin/survey/SurveyController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/SurveyController.groovy
@@ -77,7 +77,6 @@ class SurveyController extends AbstractEntityController {
 		adaptParamsForList()
 		
 		List<Survey> surveys = Survey.list(params);
-
 		if(surveys.size()>0) Collections.sort(surveys,new SurveySorter())
 
 		render (view: '/survey/admin/list', model:[
@@ -89,7 +88,7 @@ class SurveyController extends AbstractEntityController {
 	}
 	
 	def copy = {
-		def survey = getEntity(params.int('surveyId'))
+		def survey = getEntity(params.int('survey'))
 		def clone = surveyCopyService.copySurvey(survey)
 		
 		redirect (controller: 'survey', action: 'list')	

--- a/grails-app/controllers/org/chai/kevin/survey/SurveyElementController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/SurveyElementController.groovy
@@ -38,7 +38,7 @@ class SurveyElementController {
 	def surveyService;
 	
 	def getHtmlData = {
-		Survey survey = Survey.get(params.int('surveyId'));
+		Survey survey = Survey.get(params.int('survey'));
 		List<String> allowedTypes = params.list('include');
 		Set<SurveyElement> surveyElements = surveyService.searchSurveyElements(params['searchText'], survey, allowedTypes, params);
 		
@@ -49,7 +49,7 @@ class SurveyElementController {
 	}
 
 	def getAjaxData = {
-		Survey survey = Survey.get(params.int('surveyId'));
+		Survey survey = Survey.get(params.int('survey'));
 		List<String> allowedTypes = params.list('include');
 		Set<SurveyElement> surveyElements = surveyService.searchSurveyElements(params['term'], survey, allowedTypes, params);
 
@@ -57,8 +57,8 @@ class SurveyElementController {
 			elements = array {
 				surveyElements.each { surveyElement ->
 					elem (
-						id: surveyElement.id,
-						surveyElement: g.i18n(field: surveyElement.rawDataElement.names)+' - '+ g.i18n(field: surveyElement.surveyQuestion.section.names)+' - '+ g.i18n(field: surveyElement.survey.names) + '['+surveyElement.id+']'
+						key: surveyElement.id,
+						value: g.i18n(field: surveyElement.rawDataElement.names)+' - '+ g.i18n(field: surveyElement.surveyQuestion.section.names)+' - '+ g.i18n(field: surveyElement.survey.names) + '['+surveyElement.id+']'
 					)
 				}
 			}

--- a/grails-app/controllers/org/chai/kevin/survey/TableColumnController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/TableColumnController.groovy
@@ -43,10 +43,7 @@ class TableColumnController extends AbstractEntityController {
 		return SurveyTableColumn.get(id)
 	}
 	def createEntity() {
-		def entity = new SurveyTableColumn();
-		//FIXME find a better solution to do this
-		if (!params['question']) entity.question = SurveyTableQuestion.get(params.questionId)
-		return entity
+		return new SurveyTableColumn();
 	}
 
 	def getLabel() {

--- a/grails-app/controllers/org/chai/kevin/survey/TableQuestionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/TableQuestionController.groovy
@@ -49,10 +49,7 @@ class TableQuestionController extends AbstractEntityController {
 		return SurveyTableQuestion.get(id)
 	}
 	def createEntity() {
-		def entity = new SurveyTableQuestion();
-		//FIXME find a better to do this
-		if (!params['sectionId.id']) entity.section = SurveySection.get(params.sectionId)
-		return entity
+		return new SurveyTableQuestion();
 	}
 
 	def getLabel() {
@@ -98,10 +95,7 @@ class TableQuestionController extends AbstractEntityController {
 	}
 
 	def preview = {
-		def question = null;
-		if (NumberUtils.isNumber(params['questionId'])) {
-			question = SurveyTableQuestion.get(params['questionId'])
-		}
+		def question = SurveyTableQuestion.get(params.int('question'))
 
 		def model = getModel(question)
 		model << [template: '/survey/admin/tablePreview']

--- a/grails-app/controllers/org/chai/kevin/survey/TableRowController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/TableRowController.groovy
@@ -45,9 +45,7 @@ class TableRowController extends AbstractEntityController {
 		return SurveyTableRow.get(id)
 	}
 	def createEntity() {
-		def entity = new SurveyTableRow();
-		if(!params["question"]) entity.question = SurveyTableQuestion.get(params.questionId)
-		return entity;
+		return new SurveyTableRow();
 	}
 
 	def getLabel() {

--- a/grails-app/controllers/org/chai/kevin/survey/validation/SurveySkipRuleController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/validation/SurveySkipRuleController.groovy
@@ -27,6 +27,7 @@
  */
 package org.chai.kevin.survey.validation
 
+import org.apache.commons.lang.math.NumberUtils;
 import org.chai.kevin.AbstractEntityController
 import org.chai.kevin.survey.Survey
 import org.chai.kevin.survey.SurveyElement
@@ -49,10 +50,7 @@ class SurveySkipRuleController  extends AbstractEntityController {
 		return SurveySkipRule.get(id)
 	}
 	def createEntity() {
-		def entity = new SurveySkipRule()
-		//FIXME find a better to do this
-		if (!params['survey.id']) entity.survey = Survey.get(params.surveyId);
-		return entity;
+		return new SurveySkipRule()
 	}
 
 	def getTemplate() {
@@ -60,7 +58,11 @@ class SurveySkipRuleController  extends AbstractEntityController {
 	}
 
 	def getModel(def entity) {
-		[ skip: entity ]
+		def skippedSurveyQuestions = new ArrayList(entity.skippedSurveyQuestions)
+		[
+			skip: entity,
+			skippedSurveyQuestions: skippedSurveyQuestions
+		]
 	}
 
 	def bindParams(def entity) {
@@ -79,11 +81,14 @@ class SurveySkipRuleController  extends AbstractEntityController {
 			}
 			i++;
 		}
-						
+				
+		// we do this because automatic data binding does not work with polymorphic elements		
 		List<SurveyQuestion> questions = new ArrayList<SurveyQuestion>();
 		params.list('skippedSurveyQuestions').each { id -> 
-			def question = surveyService.getSurveyQuestion(Long.parseLong(id))
-			if (question != null) questions.add(question);
+			if (NumberUtils.isDigits(id)) {
+				def question = surveyService.getSurveyQuestion(Long.parseLong(id))
+				if (question != null) questions.add(question);
+			}
 		}
 		entity.skippedSurveyQuestions = questions
 	}
@@ -91,7 +96,7 @@ class SurveySkipRuleController  extends AbstractEntityController {
 	def list = {
 		adaptParamsForList()
 		
-		Survey survey = Survey.get(params.int('surveyId'))
+		Survey survey = Survey.get(params.int('survey.id'))
 		List<SurveySkipRule> skipRules = new ArrayList(survey.skipRules);
 		skipRules.sort {it.id}
 		

--- a/grails-app/controllers/org/chai/kevin/survey/validation/SurveyValidationRuleController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/validation/SurveyValidationRuleController.groovy
@@ -53,10 +53,7 @@ class SurveyValidationRuleController extends AbstractEntityController {
 	}
 	
 	def createEntity() {
-		def entity = new SurveyValidationRule()
-		//FIXME find a better to do this
-		if (!params['surveyElement.id']) entity.surveyElement = SurveyElement.get(params.int('elementId'));
-		return entity;
+		return new SurveyValidationRule()
 	}
 
 	def getTemplate() {
@@ -64,7 +61,13 @@ class SurveyValidationRuleController extends AbstractEntityController {
 	}
 
 	def getModel(def entity) {
+		def surveyElements = []
+		if (entity.surveyElement != null) surveyElements << entity.surveyElement
+
+		def dependencies = new ArrayList(entity.dependencies)		
 		[
+			dependencies: dependencies,
+			surveyElements: surveyElements,
 			validation: entity,
 			types: DataEntityType.list()
 		]
@@ -95,12 +98,12 @@ class SurveyValidationRuleController extends AbstractEntityController {
 		
 		List<SurveyValidationRule> validationRules = new ArrayList<SurveyValidationRule>();
 		SurveyElement surveyElement = null
-		if (params.int('elementId')) {		
-			surveyElement = SurveyElement.get(params.int('elementId'))
+		if (params.int('surveyElement.id')) {		
+			surveyElement = SurveyElement.get(params.int('surveyElement.id'))
 			validationRules.addAll(surveyElement.getValidationRules());
 		}
 		else {
-			Survey survey = Survey.get(params.int('surveyId'))
+			Survey survey = Survey.get(params.int('survey.id'))
 			Set<SurveyElement> surveyElements = surveyService.getSurveyElements(null, survey)
 			surveyElements.each { element ->
 				validationRules.addAll(element.getValidationRules())	

--- a/grails-app/taglib/org/chai/kevin/DataEntryTagLib.groovy
+++ b/grails-app/taglib/org/chai/kevin/DataEntryTagLib.groovy
@@ -28,10 +28,10 @@ class DataEntryTagLib {
 		if (value != null && !value.isNull()) {
 			switch (type.type) {
 				case (ValueType.ENUM):
-					def enume = enums[type.enumCode]
+					def enume = enums?.get(type.enumCode)
 					if (enume == null) result = value.enumValue
 					else {
-						def option = enume.getOptionForValue(value.enumValue)
+						def option = enume?.getOptionForValue(value.enumValue)
 						if (option == null) result = value.enumValue
 						else result = languageService.getText(option.names)
 					}
@@ -53,7 +53,7 @@ class DataEntryTagLib {
 		def enume = attrs['enum']
 		def var = attrs['var']
 		
-		def options = enume.activeEnumOptions.sort(getOrderingComparator())
+		def options = enume==null?[]:enume.activeEnumOptions?.sort(getOrderingComparator())
 
 		for (option in options) {
 			if (var) {

--- a/grails-app/views/entity/data/_createEnumOption.gsp
+++ b/grails-app/views/entity/data/_createEnumOption.gsp
@@ -5,18 +5,18 @@
 		<div class="clear"></div>
 	</div>
 	<g:form url="[controller:'enumOption', action:'save', params:[targetURI: targetURI]]" useToken="true">
-	<input type="hidden" name="enume.id" value="${option.enume.id}"/>
-	<g:i18nTextarea name="names" bean="${option}" value="${option.names}" label="Option" field="names" height="100"  width="300" maxHeight="100" />
-	<g:i18nInput name="order" label="Order" bean="${option}" value="${option.order}" field="order"/>
-	
-	<g:input name="value" label="Value" bean="${option}" field="value"/>
-	
-	<div class="row">
-		<label>Inactive</label>
-		<g:checkBox name="inactive" value="${option.inactive}" />
-	</div>
+		<input type="hidden" name="enume.id" value="${option.enume.id}"/>
+		<g:i18nTextarea name="names" bean="${option}" value="${option.names}" label="Option" field="names" height="100"  width="300" maxHeight="100" />
+		<g:i18nInput name="order" label="Order" bean="${option}" value="${option.order}" field="order"/>
 		
-	<g:if test="${option.id != null}">
+		<g:input name="value" label="Value" bean="${option}" field="value"/>
+		
+		<div class="row">
+			<label>Inactive</label>
+			<g:checkBox name="inactive" value="${option.inactive}" />
+		</div>
+			
+		<g:if test="${option.id != null}">
 			<input type="hidden" name="id" value="${option.id}"></input>
 		</g:if>
 		<div class="row">

--- a/grails-app/views/entity/data/_enumList.gsp
+++ b/grails-app/views/entity/data/_enumList.gsp
@@ -36,7 +36,7 @@
 					<div class="hidden js_dropdown-list manage-list dropdown-list">
 						<ul>
 							<li>
-								<a href="${createLink(controller:'enumOption', action:'list',params:[enumId: enumation.id])}">
+								<a href="${createLink(controller:'enumOption', action:'list', params:['enume.id': enumation.id])}">
 									<g:message code="default.list.label" args="[message(code:'enum.enumoption.label')]" />
 								</a>
 							</li>

--- a/grails-app/views/survey/admin/_addQuestion.gsp
+++ b/grails-app/views/survey/admin/_addQuestion.gsp
@@ -4,17 +4,17 @@
 		<div class="hidden dropdown-list js_dropdown-list">
 			<ul>
 				<li>
-					<a href="${createLinkWithTargetURI(controller:'simpleQuestion', action:'create', params:[sectionId: section.id])}">
+					<a href="${createLinkWithTargetURI(controller:'simpleQuestion', action:'create', params:['section.id': section.id])}">
 						<g:message code="default.new.label" args="[message(code:'survey.simplequestion.label',default:'Simple Question')]"/>
 					</a>
 				</li>
 				<li>
-					<a href="${createLinkWithTargetURI(controller:'checkboxQuestion', action:'create', params:[sectionId: section.id])}">
+					<a href="${createLinkWithTargetURI(controller:'checkboxQuestion', action:'create', params:['section.id': section.id])}">
 						<g:message code="default.new.label" args="[message(code:'survey.checkboxquestion.label',default:'Checkbox Question')]"/>
 					</a>
 				</li>
 				<li>
-					<a href="${createLinkWithTargetURI(controller:'tableQuestion', action:'create', params:[sectionId: section.id])}">
+					<a href="${createLinkWithTargetURI(controller:'tableQuestion', action:'create', params:['section.id': section.id])}">
 						<g:message code="default.new.label" args="[message(code:'survey.tablequestion.label',default:'Table Question')]"/>
 					</a>
 				</li>

--- a/grails-app/views/survey/admin/_checkboxOption.gsp
+++ b/grails-app/views/survey/admin/_checkboxOption.gsp
@@ -6,7 +6,7 @@
 		<g:message code="default.link.delete.label" default="Delete" />
 	</a>
 	<g:if test="${option.surveyElement != null}">
-        <a href="${createLink(controller:'surveyValidationRule', action:'list', params:[elementId: option.surveyElement.id])}">
+        <a href="${createLink(controller:'surveyValidationRule', action:'list', params:['surveyElement.id': option.surveyElement.id])}">
         <g:message code="survey.viewvalidationrule.label" default="View Validation Rules" />
         </a> 
 	</g:if>

--- a/grails-app/views/survey/admin/_createCheckboxQuestion.gsp
+++ b/grails-app/views/survey/admin/_createCheckboxQuestion.gsp
@@ -25,25 +25,15 @@
 							</li>
 						</g:each>
 					</ul>
-					<a href="${createLinkWithTargetURI(controller:'checkboxOption', action:'create', params:[questionId: question.id])}">
+					<a href="${createLinkWithTargetURI(controller:'checkboxOption', action:'create', params:['question.id': question.id])}">
 						<g:message code="default.add.label" args="[message(code:'survey.checkboxquestion.checkboxoption.label')]" default="Add Option" />
 					</a>
 				</div>
 			</div>
 		</g:if>
 		
-		<div class="row ${hasErrors(bean:question, field:'section', 'errors')}">
-			<label for="section.id"><g:message code="survey.section.label" default="Section"/>:</label>
-			<select class="section-list" name="section.id">
-				<option value="null">-- <g:message code="default.select.label" args="[message(code:'survey.section.label')]" default="Select a Section"/> --</option>
-				<g:each in="${sections}" var="section">
-					<option value="${section.id}" ${section.id+''==fieldValue(bean: question, field: 'section.id')+''?'selected="selected"':''}>
-						<g:i18n field="${section.names}"/>
-					</option>
-				</g:each>
-			</select>
-			<div class="error-list"><g:renderErrors bean="${question}" field="section" /></div>
-		</div>
+		<g:selectFromList name="section.id" label="${message(code:'survey.section.label')}" field="section" optionKey="id" multiple="false"
+			from="${sections}" value="${question.section?.id}" bean="${question}" values="${sections.collect {i18n(field:it.names)}}" />
 		
 		<g:selectFromList name="typeCodes" label="${message(code:'facility.type.label')}" bean="${question}" field="typeCodeString" 
 			from="${types}" value="${question.typeCodes*.toString()}" values="${types.collect{i18n(field:it.names)}}" optionKey="code" multiple="true"/>

--- a/grails-app/views/survey/admin/_createSection.gsp
+++ b/grails-app/views/survey/admin/_createSection.gsp
@@ -10,20 +10,9 @@
 	<g:form url="[controller:'section', action:'save', params:[targetURI:targetURI]]" useToken="true">
 		<g:i18nInput name="names" bean="${section}" value="${section?.names}" label="Name" field="names" />
 			
-		<div class="row">
-			<div class="${hasErrors(bean:section, field:'objective', 'errors')}">
-				<label for="objective.id"><g:message code="survey.objective.label" default="Objective"/>:</label>
-				<select class="objective-list" name="objective.id">
-					<option value="null">-- <g:message code="survey.selectanobjective.label" default="Select an Objective"/> --</option>
-					<g:each in="${objectives}" var="objective">
-						<option value="${objective.id}" ${objective.id+''==fieldValue(bean: section, field: 'objective.id')+''?'selected="selected"':''}>
-							<g:i18n field="${objective.names}"/>
-						</option>
-					</g:each>
-				</select>
-				<div class="error-list"><g:renderErrors bean="${section}" field="objective" /></div>
-			</div>
-		</div>
+		<g:selectFromList name="objective.id" label="${message(code:'survey.objective.label')}" field="objective" optionKey="id" multiple="false"
+			from="${objectives}" value="${section.objective?.id}" bean="${section}" values="${objectives.collect {i18n(field:it.names)}}" />
+			
 		<g:selectFromList name="typeCodes" label="${message(code:'facility.type.label')}" bean="${section}" field="typeCodeString" 
 			from="${types}" value="${section.typeCodes*.toString()}" values="${types.collect{i18n(field:it.names)}}" optionKey="code" multiple="true"/>
 

--- a/grails-app/views/survey/admin/_createSimpleQuestion.gsp
+++ b/grails-app/views/survey/admin/_createSimpleQuestion.gsp
@@ -19,7 +19,7 @@
 					<label for="surveyElement.dataElement.name"><g:message code="dataelement.label" default="Data Element"/>:</label>
 					<input type="text" name="surveyElement.dataElement.name" value="${i18n(field: question.surveyElement?.dataElement?.names)}" id="data-element-name" class="idle-field" disabled />
 					<g:if test="${question.surveyElement?.id != null}">
-						<span><a href="${createLink(controller:'surveyValidationRule', action:'list', params:[elementId: question.surveyElement?.id])}"> <g:message code="default.list.label" args="[message(code:'survey.validationrule.label',default:'Validation Rules')]" /></a> </span>
+						<span><a href="${createLink(controller:'surveyValidationRule', action:'list', params:['surveyElement.id': question.surveyElement?.id])}"> <g:message code="default.list.label" args="[message(code:'survey.validationrule.label',default:'Validation Rules')]" /></a> </span>
 					</g:if>
 					<div class="error-list">
 						<g:renderErrors bean="${question}" field="surveyElement" />
@@ -40,20 +40,9 @@
 
 				<g:input name="order" label="Order" bean="${question}" field="order" />
 
-				<div class="row ${hasErrors(bean:question, field:'section', 'errors')}">
-					<label for="section.id"><g:message code="survey.section.label" default="Section"/>:</label> <select name="section.id">
-						<option value="null">-- <g:message code="default.select.label" args="[message(code:'survey.section.label')]" default="Select a Section"/> --</option>
-						<g:each in="${sections}" var="section">
-							<option value="${section.id}" ${section.id+''==fieldValue(bean: question, field: 'section.id')+''?'selected="selected"':''}>
-								<g:i18n field="${section.names}" />
-							</option>
-						</g:each>
-					</select>
-					<div class="error-list">
-						<g:renderErrors bean="${question}" field="section" />
-					</div>
-				</div>
-
+				<g:selectFromList name="section.id" label="${message(code:'survey.section.label')}" field="section" optionKey="id" multiple="false"
+					from="${sections}" value="${question.section?.id}" bean="${question}" values="${sections.collect {i18n(field:it.names)}}" />
+			
 				<g:selectFromList name="typeCodes" label="${message(code:'facility.type.label')}" bean="${question}" field="typeCodeString" 
 					from="${types}" value="${question.typeCodes*.toString()}" values="${types.collect{i18n(field:it.names)}}" optionKey="code" multiple="true"/>
 

--- a/grails-app/views/survey/admin/_createSkipRule.gsp
+++ b/grails-app/views/survey/admin/_createSkipRule.gsp
@@ -10,6 +10,7 @@
 		<div class="data-field-column">
 		<g:form url="[controller:'surveySkipRule', action:'save', params:[targetURI:targetURI]]" useToken="true">
 			<input type="hidden" name="survey.id" value="${skip.survey.id}" />
+			
 			<div class="row">
 				<label><g:message code="survey.label" default="Survey"/>:</label>
 			 	<input type="text" name="survey.id" value="${i18n(field: skip.survey.names)}" class="idle-field" disabled />
@@ -53,20 +54,11 @@
 				<div class="error-list"><g:renderErrors bean="${skip}" field="skippedSurveyElements" /></div>
 			</div>
 
-			<div class="row ${hasErrors(bean:skip, field:'skippedSurveyQuestions', 'errors')}">
-				<label><g:message code="survey.skiprule.skippedquestions.label" default="Questions to Skip"/>: </label>
-				<select id="questions-list" name="skippedSurveyQuestions" multiple="true" class="ajax-search-field">
-					<g:if test="${!skip.skippedSurveyQuestions.isEmpty()}">
-						<g:each in="${skip.skippedSurveyQuestions}" var="question">
-							<option value="${question.id}" selected>
-								<g:stripHtml field="${question.names}" chars="35"/> - <g:i18n field="${question.section.names}"/>
-							</option>
-						</g:each>
-					</g:if>
-				</select>
-				<div class="error-list"><g:renderErrors bean="${skip}" field="skippedSurveyQuestions" /></div>
-			</div>
-			
+			<g:selectFromList name="skippedSurveyQuestions" label="${message(code:'survey.skiprule.skippedquestions.label')}" field="skippedSurveyQuestions" 
+					optionKey="id" multiple="true" ajaxLink="${createLink(controller:'question', action:'getAjaxData', params:[survey: skip.survey.id])}" 
+					from="${skippedSurveyQuestions}" value="${skip.skippedSurveyQuestions*.id}" bean="${skip}" 
+					values="${skippedSurveyQuestions.collect {i18n(field:it.names)+' - '+i18n(field:it.section?.names)}}" />
+
 		 	<g:textarea name="expression" label="Expression" bean="${skip}" field="expression" rows="5"/>
 		 
 			<g:if test="${skip.id != null}">
@@ -98,23 +90,11 @@
 		$(".skipped-survey-elements-list").ajaxChosen({
 			type : 'GET',
 			dataType: 'json',
-			url : "${createLink(controller:'surveyElement', action:'getAjaxData', params:[surveyId: skip.survey.id])}"
+			url : "${createLink(controller:'surveyElement', action:'getAjaxData', params:[survey: skip.survey.id])}"
 		}, function (data) {
 			var terms = {};
 			$.each(data.elements, function (i, val) {
-				terms[val.id] = val.surveyElement;
-			});
-			return terms;
-		});
-		
-		$("#questions-list").ajaxChosen({
-			type : 'GET',
-			dataType: 'json',
-			url : "${createLink(controller:'question', action:'getAjaxData', params:[surveyId: skip.survey.id])}"
-		}, function (data) {
-			var terms = {};
-			$.each(data.questions, function (i, val) {
-				terms[val.id] = val.question;
+				terms[val.key] = val.value;
 			});
 			return terms;
 		});

--- a/grails-app/views/survey/admin/_createTableQuestion.gsp
+++ b/grails-app/views/survey/admin/_createTableQuestion.gsp
@@ -16,7 +16,7 @@
 		<g:if test="${question.id != null}">
 			<input type="hidden" name="id" value="${question.id}"></input>
 			<div class="row">
-				<a href="${createLinkWithTargetURI(controller:'tableQuestion', action:'preview',params:[questionId: question.id])}">
+				<a href="${createLinkWithTargetURI(controller:'tableQuestion', action:'preview',params:['question': question.id])}">
 					<g:message code="survey.tablequestion.preview.label" default="Preview"/></a>
 				</a>
 			</div>
@@ -31,7 +31,7 @@
 							</li>
 						</g:each>
 					</ul>
-					<a href="${createLinkWithTargetURI(controller:'tableColumn', action:'create', params:[questionId: question.id])}">
+					<a href="${createLinkWithTargetURI(controller:'tableColumn', action:'create', params:['question.id': question.id])}">
 						<g:message code="default.add.label" args="[message(code:'survey.tablequestion.tablecolumn.label')]" />
 					</a>
 				</div>
@@ -47,7 +47,7 @@
 							</li>
 						</g:each>
 					</ul>
-					<a href="${createLinkWithTargetURI(controller:'tableRow', action:'create', params:[questionId: question.id])}">
+					<a href="${createLinkWithTargetURI(controller:'tableRow', action:'create', params:['question.id': question.id])}">
 						<g:message code="default.add.label" args="[message(code:'survey.tablequestion.tablerow.label')]" />
 					</a>
 				</div>
@@ -55,19 +55,10 @@
 		</g:if>
 		
 		<g:input name="order" label="Order" bean="${question}" field="order"/>
-		<div class="row ${hasErrors(bean:question, field:'section', 'errors')}">
-			<label for="section.id"><g:message code="survey.section.label" default="Section"/>:</label>
-			<select class="section-list" name="section.id">
-				<option value="null">-- <g:message code="default.select.label" args="[message(code:'survey.section.label')]" default="Select a Section"/> --</option>
-				<g:each in="${sections}" var="section">
-					<option value="${section.id}" ${section.id+''==fieldValue(bean: question, field: 'section.id')+''?'selected="selected"':''}>
-						<g:i18n field="${section.names}"/>
-					</option>
-				</g:each>
-			</select>
-			<div class="error-list"><g:renderErrors bean="${question}" field="section" /></div>
-		</div>
 		
+		<g:selectFromList name="section.id" label="${message(code:'survey.section.label')}" field="section" optionKey="id" multiple="false"
+			from="${sections}" value="${question.section?.id}" bean="${question}" values="${sections.collect {i18n(field:it.names)}}" />
+
 		<g:selectFromList name="typeCodes" label="${message(code:'facility.type.label')}" bean="${question}" field="typeCodeString" 
 			from="${types}" value="${question.typeCodes*.toString()}" values="${types.collect{i18n(field:it.names)}}" optionKey="code" multiple="true"/>
 

--- a/grails-app/views/survey/admin/_createValidationRule.gsp
+++ b/grails-app/views/survey/admin/_createValidationRule.gsp
@@ -9,43 +9,27 @@
 	<div class="forms-container"">
 		<div class="data-field-column">
 			<g:form url="[controller:'surveyValidationRule', action:'save', params:[targetURI: targetURI]]" useToken="true">
-			
-				<div class="row ${hasErrors(bean:validation, field:'surveyElement', 'errors')}">
-					<label for="surveyElement.id"><g:message code="survey.surveyelement.label" default="Survey Element"/></label>
-				    <select id="elements-list" name="surveyElement.id" class="ajax-search-field">
-						<g:if test="${validation.surveyElement?.id != null}">
-							<option value="${validation.surveyElement.id}" selected>
-								<g:i18n field="${validation.surveyElement.dataElement.names}" />[${validation.surveyElement.id}]
-							</option>
-						</g:if>
-					</select>
-					<div class="error-list"><g:renderErrors bean="${validation}" field="surveyElement" /></div>
-				</div>
+
+				<g:selectFromList name="surveyElement.id" label="${message(code:'survey.surveyelement.label')}" field="surveyElement" optionKey="id" multiple="false"
+					ajaxLink="${createLink(controller:'surveyElement', action:'getAjaxData')}" from="${surveyElements}"
+					value="${validation.surveyElement?.id}" bean="${validation}"
+					values="${surveyElements.collect {i18n(field:it.dataElement.names)+' - '+i18n(field:it.surveyQuestion?.section?.names)+' - '+i18n(field:it.survey?.names)+'['+it.id+']'}}" />
 			
 				<g:input name="prefix" label="${message(code:'survey.validationrule.prefix.label')}" bean="${validation}" field="prefix"/>
 		 		<g:i18nRichTextarea name="messages" bean="${validation}" value="${validation.messages}" label="Messages" field="messages" height="150"  width="400" maxHeight="100" />
 		 		
-				<div class="row ${hasErrors(bean:validation, field:'dependencies', 'errors')}">
-					<label><g:message code="survey.validationrule.dependencies.label" default="Dependencies"/>: </label>
-				    <select id="dependencies-list" name="dependencies" multiple="true" class="ajax-search-field">
-						<g:if test="${validation.dependencies.size() != 0}">
-							<g:each in="${validation.dependencies}" var="dependency">
-								<option value="${dependency.id}" selected>
-									<g:i18n field="${dependency.dataElement.names}" />
-									[${dependency.id}]
-								</option>
-							</g:each>
-						</g:if>
-					</select>
-					<div class="error-list"><g:renderErrors bean="${validation}" field="dependencies" /></div>
-				</div>
-		
+		 		<g:selectFromList name="dependencies" label="${message(code:'survey.validationrule.dependencies.label')}" field="dependencies" optionKey="id" multiple="true"
+					ajaxLink="${createLink(controller:'surveyElement', action:'getAjaxData')}" from="${dependencies}" 
+					value="${validation.dependencies*.id}" bean="${validation}"
+					values="${dependencies.collect {i18n(field:it.dataElement.names)+' - '+i18n(field:it.surveyQuestion?.section?.names)+' - '+i18n(field:it.survey?.names)+'['+it.id+']'}}" />
+			
 				<div class="row">
 					<label><g:message code="survey.validationrule.allowoutlier.label" default="Allow Outlier"/></label>
 					<g:checkBox name="allowOutlier" value="${validation.allowOutlier}" />
 				</div>
 				
-				<g:textarea name="expression" label="Expression" bean="${validation}" field="expression" rows="5"/>
+				<g:textarea name="expression" label="Expression" bean="${validation}" field="expression" value="${validation.expression}" rows="5"/>
+				
 				<g:selectFromList name="typeCodes" label="${message(code:'facility.type.label')}" bean="${validation}" field="typeCodeString" 
 					from="${types}" value="${validation.typeCodes*.toString()}" values="${types.collect{i18n(field:it.names)}}" optionKey="code" multiple="true"/>
 			
@@ -76,30 +60,6 @@
 
 <script type="text/javascript">
 	$(document).ready(function() {		
-		$("#dependencies-list").ajaxChosen({
-			type : 'GET',
-			dataType: 'json',
-			url : "${createLink(controller:'surveyElement', action:'getAjaxData')}"
-		}, function (data) {
-			var terms = {};
-			$.each(data.elements, function (i, val) {
-				terms[val.id] = val.surveyElement;
-			});
-			return terms;
-		});
-		
-		$("#elements-list").ajaxChosen({
-			type : 'GET',
-			dataType: 'json',
-			url : "${createLink(controller:'surveyElement', action:'getAjaxData')}"
-		}, function (data) {
-			var terms = {};
-			$.each(data.elements, function (i, val) {
-				terms[val.id] = val.surveyElement;
-			});
-			return terms;
-		});
-		
 		getDataElement(function(event){
 			if ($('.in-edition').size() == 1) {
 				var edition = $('.in-edition')[0]

--- a/grails-app/views/survey/admin/_objectiveList.gsp
+++ b/grails-app/views/survey/admin/_objectiveList.gsp
@@ -1,4 +1,4 @@
-<g:searchBox controller="question" action="search" params="${[surveyId: survey?.id]}" entityName="Survey Question"/>
+<g:searchBox controller="question" action="search" params="${[survey: survey?.id]}" entityName="Survey Question"/>
 <table class="listing">
 	<thead>
 		<tr>
@@ -37,7 +37,7 @@
 						<div class="hidden manage-list js_dropdown-list dropdown-list">
 							<ul>
 								<li>
-									<a href="${createLink(controller:'section', action:'list', params:[surveyId:survey?.id,objectiveId: objective.id])}">
+									<a href="${createLink(controller:'section', action:'list', params:['objective.id': objective.id])}">
 										<g:message code="default.list.label" args="[message(code:'survey.section.label',default:'Section')]" />
 									</a>
 								</li>

--- a/grails-app/views/survey/admin/_sectionList.gsp
+++ b/grails-app/views/survey/admin/_sectionList.gsp
@@ -36,7 +36,7 @@
 						<div class="hidden manage-list dropdown-list js_dropdown-list">
 							<ul>
 								<li>
-									<a href="${createLink(controller:'question', action:'list',params:[surveyId:objective.survey?.id,objectiveId: objective?.id,sectionId: section.id])}">
+									<a href="${createLink(controller:'question', action:'list',params:['section.id': section.id])}">
 										<g:message code="default.list.label" args="[message(code:'survey.question.label',default:'Questions')]" />
 									</a>
 								</li>

--- a/grails-app/views/survey/admin/_surveyList.gsp
+++ b/grails-app/views/survey/admin/_surveyList.gsp
@@ -38,16 +38,16 @@
 						<div class="hidden manage-list dropdown-list js_dropdown-list">
 							<ul>
 								<li>
-									<a href="${createLink(controller:'objective', action:'list', params:[surveyId:survey?.id])}"><g:message code="default.list.label" args="[message(code:'survey.objective.label',default:'Objective')]" /></a>
+									<a href="${createLink(controller:'objective', action:'list', params:['survey.id':survey?.id])}"><g:message code="default.list.label" args="[message(code:'survey.objective.label',default:'Objective')]" /></a>
 								</li>
 								<li>
-									<a href="${createLink(controller:'surveySkipRule', action:'list', params:[surveyId: survey?.id])}"><g:message code="default.list.label" args="[message(code:'survey.skiprule.label',default:'Skip Rules')]" /></a>
+									<a href="${createLink(controller:'surveySkipRule', action:'list', params:['survey.id': survey?.id])}"><g:message code="default.list.label" args="[message(code:'survey.skiprule.label',default:'Skip Rules')]" /></a>
 								</li>
 								<li>
-									<a href="${createLink(controller:'surveyValidationRule', action:'list', params:[surveyId: survey?.id])}"><g:message code="default.list.label" args="[message(code:'survey.validationrule.label',default:'Validation Rules')]" /></a>
+									<a href="${createLink(controller:'surveyValidationRule', action:'list', params:['survey.id': survey?.id])}"><g:message code="default.list.label" args="[message(code:'survey.validationrule.label',default:'Validation Rules')]" /></a>
 								</li>
 								<li>
-							    	<a href="${createLink(controller:'survey', action:'copy', params:[surveyId: survey.id])}"><g:message code="survey.clone.label" default="Clone" /> </a>
+							    	<a href="${createLink(controller:'survey', action:'copy', params:['survey.id': survey.id])}"><g:message code="survey.clone.label" default="Clone" /> </a>
 								</li>
 							</ul>
 						</div>

--- a/grails-app/views/survey/admin/_surveyList.gsp
+++ b/grails-app/views/survey/admin/_surveyList.gsp
@@ -47,7 +47,7 @@
 									<a href="${createLink(controller:'surveyValidationRule', action:'list', params:['survey.id': survey?.id])}"><g:message code="default.list.label" args="[message(code:'survey.validationrule.label',default:'Validation Rules')]" /></a>
 								</li>
 								<li>
-							    	<a href="${createLink(controller:'survey', action:'copy', params:['survey.id': survey.id])}"><g:message code="survey.clone.label" default="Clone" /> </a>
+							    	<a href="${createLink(controller:'survey', action:'copy', params:[survey: survey.id])}"><g:message code="survey.clone.label" default="Clone" /> </a>
 								</li>
 							</ul>
 						</div>

--- a/grails-app/views/survey/admin/_tablePreview.gsp
+++ b/grails-app/views/survey/admin/_tablePreview.gsp
@@ -41,16 +41,14 @@
 						<g:set var="dataElement" value="${surveyElement?.dataElement}"/>
 							<td class="element-${surveyElement?.id} element" data-element="${surveyElement?.id}">
 								<g:render template="/survey/element/${dataElement.type.type.name().toLowerCase()}" model="[
-									value: null,
-									lastValue: null,
 									type: dataElement.type, 
 									suffix: '',
-									surveyElement: surveyElement,
+									element: surveyElement,
 									enteredValue: null,
 									readonly: readonly
 								]" />
 								
-								<a href="${createLink(controller:'surveyValidationRule', action:'list', params:[elementId: surveyElement?.id])}">
+								<a href="${createLink(controller:'surveyValidationRule', action:'list', params:['surveyElement.id': surveyElement?.id])}">
 									<g:message code="survey.viewvalidationrule.label" default="View Validation Rules"/>
 								</a>
 							</td>

--- a/grails-app/views/survey/admin/list.gsp
+++ b/grails-app/views/survey/admin/list.gsp
@@ -18,7 +18,7 @@
 			<g:if test="${survey}">
 				<li>
 					&rarr; 
-					<a href="${createLink(controller: 'objective', action:'list', params:[surveyId: survey.id])}">
+					<a href="${createLink(controller: 'objective', action:'list', params:['survey.id': survey.id])}">
 						<g:i18n field="${survey.names}" />
 					</a>
 				</li>
@@ -26,7 +26,7 @@
 			<g:if test="${objective}">
 				<li>
 					&rarr; 
-					<a href="${createLink(controller: 'section', action:'list', params:[surveyId: survey.id, objectiveId: objective.id])}">
+					<a href="${createLink(controller: 'section', action:'list', params:['objective.id': objective.id])}">
 						<g:i18n field="${objective.names}" />
 					</a>
 				</li>
@@ -34,7 +34,7 @@
 			<g:if test="${section}">
 				<li>
 					&rarr; 
-					<a href="${createLink(controller: 'question', action:'list', params:[surveyId: survey.id, objectiveId: section.objective.id, sectionId: section.id])}">
+					<a href="${createLink(controller: 'question', action:'list', params:['section.id': section.id])}">
 						<g:i18n field="${section.names}" /> 
 					</a>
 				</li>

--- a/grails-app/views/survey/element/_enum.gsp
+++ b/grails-app/views/survey/element/_enum.gsp
@@ -1,5 +1,5 @@
 <g:if test="${type.enumCode != null}">
-	<g:set var="enume" value="${enums[type.enumCode]}"/>
+	<g:set var="enume" value="${enums?.get(type.enumCode)}"/>
 </g:if>
 
 <!-- Enum type question -->

--- a/grails-app/views/tags/form/_selectFromList.gsp
+++ b/grails-app/views/tags/form/_selectFromList.gsp
@@ -1,10 +1,10 @@
 <g:set var="multiple" value="${multiple!=null&&multiple=='true'}"/>
 <g:set var="random" value="${org.apache.commons.lang.math.RandomUtils.nextInt()}"/>
 
-<div class="row ${hasErrors(bean:target,field:field,'errors')}">
+<div class="row ${hasErrors(bean:bean, field:field, 'errors')}">
 	<g:if test="${multiple}"><input type="hidden" name="${name}" value=""/></g:if>
 	<label for="${name}">${label}</label>
-	<select id="options-${random}" name="${name}" ${multiple?'multiple':''}>
+	<select id="options-${random}" name="${name}" ${multiple?'multiple':''} style="min-width:300px">
 		<g:if test="${!multiple}"><option value="">-- Please select from the list --</option></g:if>
 		<g:each in="${from}" var="item" status="i">
 			<option value="${item[optionKey]}" ${(multiple?value?.contains(item[optionKey]):item[optionKey].equals(value))?'selected':''}>

--- a/grails-app/views/templates/_genericList.gsp
+++ b/grails-app/views/templates/_genericList.gsp
@@ -5,7 +5,7 @@
 	     	<g:if test="${!search}">
 		     	<span class="right">
 					<g:if test="${!addTemplate}">
-		  				<a href="${createLinkWithTargetURI(controller: params['controller'], action:'create', params: params)}">
+		  				<a href="${createLinkWithTargetURI(controller: controllerName, action:'create')+'&'+request.queryString}">
 		  					<g:message code="default.new.label" args="[entityName]"/>
 		  				</a>
 		  			</g:if>

--- a/test/integration/org/chai/kevin/DataEntryTagLibTests.groovy
+++ b/test/integration/org/chai/kevin/DataEntryTagLibTests.groovy
@@ -12,16 +12,18 @@ class DataEntryTagLibTests extends GroovyPagesTestCase {
 	
 	def languageService
 	
-//	def testEachOption() {
-//		def option1 = new EnumOption(value: "1", order: IntegrationTests.o(['en':2, 'fr':1]))
-//		def option2 = new EnumOption(value: "2", order: IntegrationTests.o(['en':1, 'fr':2]))
-//		def enume = new Enum(enumOptions: [option1, option2])
-//
-//		assertEquals applyTemplate(
-//			'<g:eachOption enum="${enume}" var="option">${option.value} </g:eachOption>',
-//			['enume':enume]
-//		), '2 1 '
-//		
+	def testEachOption() {
+		def option1 = new EnumOption(value: "1", order: IntegrationTests.o(['en':2, 'fr':1]))
+		def option2 = new EnumOption(value: "2", order: IntegrationTests.o(['en':1, 'fr':2]))
+		def enume = new Enum(enumOptions: [option1, option2])
+
+		assertEquals applyTemplate(
+			'<g:eachOption enum="${enume}" var="option">${option.value} </g:eachOption>',
+			['enume':enume]
+		), '2 1 '
+		
+	}
+	// this does not work because it modifies the metaClass of languageService for all the tests
 //		languageService.metaClass.currentLanguage = { return "fr";}
 //		languageService.metaClass.getCurrentLanguage = { return "fr";}
 //		
@@ -32,7 +34,24 @@ class DataEntryTagLibTests extends GroovyPagesTestCase {
 //	
 //		languageService.metaClass.remove('currentLanguage')
 //		languageService.metaClass.remove('getCurrentLanguage')
-//	}
+
+		
+	def testEachOptionWithNullEnums() {
+		assertEquals applyTemplate('<g:eachOption var="option">${option.value}</g:eachOption>'), ''
+	}
+	
+	def testValueWithNullEnums() {
+		
+		assertEquals applyTemplate(
+			'<g:value value="${value}" type="${type}" enums="${enums}"/>',
+			[
+				'value': new Value("{\"value\":\"value\"}"),
+				'type': Type.TYPE_ENUM("code"),
+				'enums': null
+			]
+		), 'value'
+
+	}
 	
 	def testValueWithNullValue() {
 		

--- a/test/integration/org/chai/kevin/survey/SurveySkipRuleControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/survey/SurveySkipRuleControllerSpec.groovy
@@ -43,7 +43,7 @@ class SurveySkipRuleControllerSpec extends SurveyIntegrationTests {
 		surveySkipRuleController = new SurveySkipRuleController()
 		
 		when:
-		surveySkipRuleController.params.surveyId = survey.id
+		surveySkipRuleController.params['survey.id'] = survey.id
 		surveySkipRuleController.list()
 		
 		then:


### PR DESCRIPTION
To keep things in sync with the planning admin, I simplified the views and controllers :
- used g:selectFromList wherever possible
- changed the URL params in lists from <entityId> to <entity.id> so we don't need to initialize parent entities in the createEntity() method
