### PR TITLE
Redirect to 404 when invalid params

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -64,7 +64,7 @@ class UrlMappings {
 
 		// homepage in home controller
 		"/"(controller:"home", action:"index")
-		
+		"404"(view:'/404')
 		"500"(view:'/error')
 	}
 }

--- a/grails-app/controllers/org/chai/kevin/cost/CostRampUpController.groovy
+++ b/grails-app/controllers/org/chai/kevin/cost/CostRampUpController.groovy
@@ -78,7 +78,7 @@ class CostRampUpController extends AbstractEntityController {
 	
 	def list = {
 		adaptParamsForList()
-		def entities = CostRampUp.list(params)
+		List<CostRampUp> entities = CostRampUp.list(params)
 		
 		render (view: '/entity/list', model: [
 			entities: entities, 

--- a/grails-app/controllers/org/chai/kevin/dashboard/DashboardObjectiveController.groovy
+++ b/grails-app/controllers/org/chai/kevin/dashboard/DashboardObjectiveController.groovy
@@ -103,7 +103,6 @@ class DashboardObjectiveController extends AbstractEntityController {
 	
 	def list = {
 		adaptParamsForList()
-		
 		List<DashboardObjective> objectives = DashboardObjective.list(params);
 		
 		render (view: '/entity/list', model:[

--- a/grails-app/controllers/org/chai/kevin/dashboard/DashboardTargetController.groovy
+++ b/grails-app/controllers/org/chai/kevin/dashboard/DashboardTargetController.groovy
@@ -96,7 +96,6 @@ class DashboardTargetController extends AbstractEntityController {
 	
 	def list = {
 		adaptParamsForList()
-		
 		List<DashboardTarget> targets = DashboardTarget.list(params);
 		
 		render (view: '/entity/list', model:[

--- a/grails-app/controllers/org/chai/kevin/data/CalculationController.groovy
+++ b/grails-app/controllers/org/chai/kevin/data/CalculationController.groovy
@@ -45,7 +45,6 @@ class CalculationController extends AbstractController {
 	
 	def list = {
 		adaptParamsForList()
-
 		List<Calculation<?>> calculations = dataService.list(Calculation.class, params)
 		
 		render (view: '/entity/list', model:[

--- a/grails-app/controllers/org/chai/kevin/data/EnumController.groovy
+++ b/grails-app/controllers/org/chai/kevin/data/EnumController.groovy
@@ -68,7 +68,6 @@ class EnumController extends AbstractEntityController {
 	
 	def list = {
 		adaptParamsForList()
-		
 		List<Enum> enums = Enum.list(params);
 		
 		render (view: '/entity/list', model:[

--- a/grails-app/controllers/org/chai/kevin/data/EnumOptionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/data/EnumOptionController.groovy
@@ -87,20 +87,24 @@ class EnumOptionController extends AbstractEntityController {
 	
 	def list = {
 		adaptParamsForList();
-		
 		Enum enume = Enum.get(params.int('enume.id'));
 		
-		List<EnumOption> options = enume.enumOptions;
-		Collections.sort(options, Ordering.getOrderableComparator(languageService.currentLanguage, languageService.fallbackLanguage))
-		
-		def max = Math.min(params['offset']+params['max'], options.size())
-		
-		render (view: '/entity/list', model:[
-			entities: options.subList(params['offset'], max),
-			template: "data/enumOptionList",
-			entityCount: options.size(),
-			code: getLabel(),
-		])
+		if (enume == null) {
+			response.sendError(404)
+		}
+		else {
+			List<EnumOption> options = enume.enumOptions;
+			Collections.sort(options, Ordering.getOrderableComparator(languageService.currentLanguage, languageService.fallbackLanguage))
+			
+			def max = Math.min(params['offset']+params['max'], options.size())
+			
+			render (view: '/entity/list', model:[
+				entities: options.subList(params['offset'], max),
+				template: "data/enumOptionList",
+				entityCount: options.size(),
+				code: getLabel(),
+			])
+		}
 	}
 		
 }

--- a/grails-app/controllers/org/chai/kevin/data/NormalizedDataElementController.groovy
+++ b/grails-app/controllers/org/chai/kevin/data/NormalizedDataElementController.groovy
@@ -120,7 +120,6 @@ class NormalizedDataElementController extends AbstractEntityController {
 	
 	def list = {
 		adaptParamsForList()
-		
 		List<NormalizedDataElement> normalizedDataElements = NormalizedDataElement.list(params);
 		
 		render (view: '/entity/list' , model:[

--- a/grails-app/controllers/org/chai/kevin/data/RawDataElementController.groovy
+++ b/grails-app/controllers/org/chai/kevin/data/RawDataElementController.groovy
@@ -152,7 +152,6 @@ class RawDataElementController extends AbstractEntityController {
 
 	def list = {
 		adaptParamsForList()
-		
 		List<RawDataElement> rawDataElements = RawDataElement.list(params);
 		
 		render (view: '/entity/list', model:[

--- a/grails-app/controllers/org/chai/kevin/dsr/DsrTargetCategoryController.groovy
+++ b/grails-app/controllers/org/chai/kevin/dsr/DsrTargetCategoryController.groovy
@@ -92,7 +92,6 @@ class DsrTargetCategoryController extends AbstractEntityController {
 	
 	def list = {
 		adaptParamsForList()
-		
 		List<DsrTargetCategory> categories = DsrTargetCategory.list(params);
 		
 		render (view: '/entity/list', model:[

--- a/grails-app/controllers/org/chai/kevin/survey/ObjectiveController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/ObjectiveController.groovy
@@ -75,17 +75,22 @@ class ObjectiveController extends AbstractEntityController {
 		adaptParamsForList()
 
 		Survey survey = Survey.get(params.int('survey.id'));
-		List<SurveyObjective> objectives = survey.objectives;
-		Collections.sort(objectives)
-		
-		def max = Math.min(params['offset']+params['max'], objectives.size())
-		
-		render (view: '/survey/admin/list', model:[
-			template:"objectiveList",
-			survey:survey,
-			entities: objectives.subList(params['offset'], max),
-			entityCount: objectives.size(),
-			code: getLabel()
-		])
+		if (survey == null) {
+			response.sendError(404)
+		}
+		else {
+			List<SurveyObjective> objectives = survey.objectives;
+			Collections.sort(objectives)
+			
+			def max = Math.min(params['offset']+params['max'], objectives.size())
+			
+			render (view: '/survey/admin/list', model:[
+				template:"objectiveList",
+				survey:survey,
+				entities: objectives.subList(params['offset'], max),
+				entityCount: objectives.size(),
+				code: getLabel()
+			])
+		}
 	}
 }

--- a/grails-app/controllers/org/chai/kevin/survey/QuestionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/QuestionController.groovy
@@ -64,23 +64,27 @@ class QuestionController extends AbstractController {
 		adaptParamsForList()
 		
 		SurveySection section = SurveySection.get(params.int('section.id'))
-		List<SurveyQuestion> questions = section.questions;
-		Collections.sort(questions)
-		
-		def max = Math.min(params['offset']+params['max'], questions.size())
-		
-		render (view: '/survey/admin/list', model:[
-			template:"questionList",
-			survey: section.objective.survey,
-			objective: section.objective,
-			section: section,
-			entities: questions.subList(params['offset'], max),
-			entityCount: questions.size(),
-			code: 'survey.question.label',
-			addTemplate: '/survey/admin/addQuestion'
-		])
+		if (section == null) {
+			response.sendError(404)
+		}
+		else {
+			List<SurveyQuestion> questions = section.questions;
+			Collections.sort(questions)
+			
+			def max = Math.min(params['offset']+params['max'], questions.size())
+			
+			render (view: '/survey/admin/list', model:[
+				template:"questionList",
+				survey: section.objective.survey,
+				objective: section.objective,
+				section: section,
+				entities: questions.subList(params['offset'], max),
+				entityCount: questions.size(),
+				code: 'survey.question.label',
+				addTemplate: '/survey/admin/addQuestion'
+			])
+		}
 	}
-	
 	
 	def getAjaxData = {
 		Survey survey = Survey.get(params.int('survey'));

--- a/grails-app/controllers/org/chai/kevin/survey/SectionController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/SectionController.groovy
@@ -75,19 +75,24 @@ class SectionController extends AbstractEntityController {
 		adaptParamsForList()
 		
 		SurveyObjective objective = SurveyObjective.get(params.int('objective.id'))
-		List<SurveySection> sections = objective.sections;
-		Collections.sort(sections)
-
-		def max = Math.min(params['offset']+params['max'], sections.size())
-		
-		render (view: '/survey/admin/list', model:[
-			template:"sectionList",
-			survey: objective.survey,
-			objective: objective,
-			entities: sections.subList(params['offset'], max),
-			entityCount: sections.size(),
-			code: getLabel()
-		])
+		if (objective == null) {
+			response.sendError(404)
+		}
+		else {
+			List<SurveySection> sections = objective.sections;
+			Collections.sort(sections)
+	
+			def max = Math.min(params['offset']+params['max'], sections.size())
+			
+			render (view: '/survey/admin/list', model:[
+				template:"sectionList",
+				survey: objective.survey,
+				objective: objective,
+				entities: sections.subList(params['offset'], max),
+				entityCount: sections.size(),
+				code: getLabel()
+			])
+		}
 	}
 
 }

--- a/grails-app/controllers/org/chai/kevin/survey/validation/SurveySkipRuleController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/validation/SurveySkipRuleController.groovy
@@ -97,17 +97,22 @@ class SurveySkipRuleController  extends AbstractEntityController {
 		adaptParamsForList()
 		
 		Survey survey = Survey.get(params.int('survey.id'))
-		List<SurveySkipRule> skipRules = new ArrayList(survey.skipRules);
-		skipRules.sort {it.id}
-		
-		def max = Math.min(params['offset']+params['max'], skipRules.size())
-		
-		render(view: '/survey/admin/list', model:[
-			template: "skipRuleList",
-			entities: skipRules.subList(params['offset'], max),
-			entityCount: skipRules.size(),
-			code: getLabel()
-		])
+		if (survey == null) {
+			response.sendError(404)
+		}
+		else {
+			List<SurveySkipRule> skipRules = new ArrayList(survey.skipRules);
+			skipRules.sort {it.id}
+			
+			def max = Math.min(params['offset']+params['max'], skipRules.size())
+			
+			render(view: '/survey/admin/list', model:[
+				template: "skipRuleList",
+				entities: skipRules.subList(params['offset'], max),
+				entityCount: skipRules.size(),
+				code: getLabel()
+			])
+		}
 	}
 
 }

--- a/grails-app/views/404.gsp
+++ b/grails-app/views/404.gsp
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Ooops</title>
+		<meta name="layout" content="main">
+		
+	</head>
+	<body>
+		<div class="subnav"/>
+		<div class="main">
+			Oooops, the page you are looking for could not be found.
+		</div>
+	</body>
+</html>

--- a/test/integration/org/chai/kevin/data/EnumOptionControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/data/EnumOptionControllerSpec.groovy
@@ -1,0 +1,20 @@
+package org.chai.kevin.data
+
+import org.chai.kevin.IntegrationTests;
+
+class EnumOptionControllerSpec extends IntegrationTests {
+
+	def enumOptionController
+	
+	def "list 404 when no enum"() {
+		setup:
+		enumOptionController = new EnumOptionController()
+		
+		when:
+		enumOptionController.list()
+		
+		then:
+		enumOptionController.modelAndView == null
+	}
+	
+}

--- a/test/integration/org/chai/kevin/planning/PlanningServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/planning/PlanningServiceSpec.groovy
@@ -69,7 +69,7 @@ class PlanningServiceSpec extends PlanningIntegrationTests {
 		
 		when:
 		def sum = newSum('($'+dataElement.id+' -> filter $.key0 == "value")[0].key1 * 2', CODE(3))
-		def planningCost = newPlanningCost(PlanningCostType.OUTGOING, sum, "", "value", planningType)
+		def planningCost = newPlanningCost(PlanningCostType.OUTGOING, sum, "[_].key1", "value", planningType)
 		refreshCalculation()
 		planningTypeBudget = planningService.getPlanningTypeBudget(planningType, DataLocationEntity.findByCode(BUTARO))
 		

--- a/test/integration/org/chai/kevin/survey/ObjectiveControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/survey/ObjectiveControllerSpec.groovy
@@ -1,0 +1,35 @@
+package org.chai.kevin.survey
+
+import org.chai.kevin.IntegrationTests;
+
+class ObjectiveControllerSpec extends SurveyIntegrationTests {
+
+	def objectiveController
+	
+	def "objective list 404 when no survey"() {
+		setup:
+		objectiveController = new ObjectiveController()
+		
+		when:
+		objectiveController.list()
+		
+		then:
+		objectiveController.modelAndView == null
+	}
+	
+	def "objective list"() {
+		setup:
+		def period = newPeriod()
+		def survey = newSurvey(period)
+		def objective = newSurveyObjective(survey, 1, [])
+		objectiveController = new ObjectiveController()
+		
+		when:
+		objectiveController.params['survey.id'] = survey.id
+		objectiveController.list()
+		
+		then:
+		objectiveController.modelAndView.model.entities.equals([objective])
+	}
+	
+}

--- a/test/integration/org/chai/kevin/survey/QuestionControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/survey/QuestionControllerSpec.groovy
@@ -19,13 +19,40 @@ class QuestionControllerSpec extends SurveyIntegrationTests {
 		questionController = new QuestionController()
 		
 		when:
-		questionController.params.surveyId = survey.id
+		questionController.params.survey = survey.id
 		questionController.params.term = 'ele'
 		questionController.getAjaxData()
 		
 		then:
-		questionController.response.contentAsString.contains('element')
+		questionController.response.contentAsString.contains('value')
+	}
+	
+	def "list when no objective 404"() {
+		setup:
+		questionController = new QuestionController()
 		
+		when:
+		questionController.list()
+		
+		then:
+		questionController.modelAndView == null
+	}
+	
+	def "question list"() {
+		setup:
+		def period = newPeriod()
+		def survey = newSurvey(period)
+		def objective = newSurveyObjective(survey, 1, [])
+		def section = newSurveySection(objective, 1, [])
+		def question = newSimpleQuestion(section, 1, [])
+		questionController = new QuestionController()
+		
+		when:
+		questionController.params['section.id'] = section.id
+		questionController.list()
+		
+		then:
+		questionController.modelAndView.model.entities.equals([question])
 	}
 	
 }

--- a/test/integration/org/chai/kevin/survey/SectionControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/survey/SectionControllerSpec.groovy
@@ -1,0 +1,36 @@
+package org.chai.kevin.survey
+
+import org.chai.kevin.IntegrationTests;
+
+class SectionControllerSpec extends SurveyIntegrationTests {
+
+	def sectionController
+	
+	def "section list 404 when no survey"() {
+		setup:
+		sectionController = new SectionController()
+		
+		when:
+		sectionController.list()
+		
+		then:
+		sectionController.modelAndView == null
+	}
+	
+	def "section list"() {
+		setup:
+		def period = newPeriod()
+		def survey = newSurvey(period)
+		def objective = newSurveyObjective(survey, 1, [])
+		def section = newSurveySection(objective, 1, [])
+		sectionController = new SectionController()
+		
+		when:
+		sectionController.params['objective.id'] = objective.id
+		sectionController.list()
+		
+		then:
+		sectionController.modelAndView.model.entities.equals([section])
+	}
+	
+}

--- a/test/integration/org/chai/kevin/survey/SurveySkipRuleControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/survey/SurveySkipRuleControllerSpec.groovy
@@ -51,4 +51,15 @@ class SurveySkipRuleControllerSpec extends SurveyIntegrationTests {
 		
 	}
 	
+	def "list skip rule when no survey 404"() {
+		setup:
+		surveySkipRuleController = new SurveySkipRuleController()
+		
+		when:
+		surveySkipRuleController.list()
+		
+		then:
+		surveySkipRuleController.modelAndView == null
+	}
+	
 }

--- a/test/integration/org/chai/kevin/survey/SurveyValidationRuleControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/survey/SurveyValidationRuleControllerSpec.groovy
@@ -53,12 +53,23 @@ class SurveyValidationRuleControllerSpec extends SurveyIntegrationTests {
 		surveyValidationRuleController = new SurveyValidationRuleController()
 		
 		when:
-		surveyValidationRuleController.params.elementId = element.id
+		surveyValidationRuleController.params['surveyElement.id'] = element.id
 		surveyValidationRuleController.list()
 		
 		then:
 		surveyValidationRuleController.modelAndView.model.entities.size() == 1
 		
+	}
+	
+	def "test list when no survey 404"() {
+		setup:
+		surveyValidationRuleController = new SurveyValidationRuleController()
+		
+		when:
+		surveyValidationRuleController.list()
+		
+		then:
+		surveyValidationRuleController.modelAndView == null
 	}
 	
 }


### PR DESCRIPTION
When someone asks for a list of enum options for an inexistant enum, it sends a 404 instead of a 500, same thing for all the survey pages.
