### PR TITLE
null values are coded as the string "null" so we can compare against null values in jaql expressions

### DIFF
--- a/grails-app/services/org/chai/kevin/JaqlService.java
+++ b/grails-app/services/org/chai/kevin/JaqlService.java
@@ -54,7 +54,7 @@ public class JaqlService {
 		Map<String, String> jaqlVariables = new HashMap<String, String>();
 		for (Entry<String, Value> variable : variables.entrySet()) {
 			// value can be null
-			if (variable.getValue() != null && !variable.getValue().isNull()) {
+			if (variable.getValue() != null) {
 				jaqlVariables.put("$"+variable.getKey(), types.get(variable.getKey()).getJaqlValue(variable.getValue()));
 			}
 		}
@@ -69,7 +69,9 @@ public class JaqlService {
 		
 		JsonValue value = null;
 		JaqlQuery query = new JaqlQuery();
+		
 		query.setQueryString(expression);
+		
 		for (Entry<String, JsonValue> entry : valueMap.entrySet()) {
 			query.setVar(entry.getKey(), entry.getValue());
 		}

--- a/src/java/org/chai/kevin/data/Type.java
+++ b/src/java/org/chai/kevin/data/Type.java
@@ -460,7 +460,7 @@ public class Type extends JSONValue {
 	}
 	
 	public Value getValueFromJaql(String jaqlString) {
-		if (jaqlString == null || jaqlString.equals("null")) return Value.NULL_INSTANCE();
+		if (jaqlString == null || jaqlString.equals("null") || jaqlString.equals("{\"isNull\":true}")) return Value.NULL_INSTANCE();
 		try {
 			JSONObject object = new JSONObject();
 			switch (getType()) {
@@ -523,7 +523,7 @@ public class Type extends JSONValue {
 	
 	public String getJaqlValue(Value value) {
 		StringBuilder result = new StringBuilder();
-		if (value.isNull()) result.append("null");
+		if (value.isNull()) result.append("{\"isNull\":true}");
 		else {
 			switch (getType()) {
 				case NUMBER:

--- a/src/java/org/chai/kevin/data/Type.java
+++ b/src/java/org/chai/kevin/data/Type.java
@@ -460,7 +460,7 @@ public class Type extends JSONValue {
 	}
 	
 	public Value getValueFromJaql(String jaqlString) {
-		if (jaqlString == null || jaqlString.equals("null") || jaqlString.equals("{\"isNull\":true}")) return Value.NULL_INSTANCE();
+		if (jaqlString == null || jaqlString.equals("null") || jaqlString.equals("\"null\"")) return Value.NULL_INSTANCE();
 		try {
 			JSONObject object = new JSONObject();
 			switch (getType()) {
@@ -523,7 +523,7 @@ public class Type extends JSONValue {
 	
 	public String getJaqlValue(Value value) {
 		StringBuilder result = new StringBuilder();
-		if (value.isNull()) result.append("{\"isNull\":true}");
+		if (value.isNull()) result.append("\"null\"");
 		else {
 			switch (getType()) {
 				case NUMBER:

--- a/test/integration/org/chai/kevin/JaqlServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/JaqlServiceSpec.groovy
@@ -31,7 +31,7 @@ class JaqlServiceSpec extends IntegrationTests {
 		expect:
 		jaqlService.evaluate("\$1.isNull == true", Type.TYPE_BOOL(), ['1': Value.NULL_INSTANCE()], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_BOOL(true) )
 		jaqlService.evaluate("\$1.isNull == false", Type.TYPE_BOOL(), ['1': Value.NULL_INSTANCE()], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_BOOL(false) )
-		
+		jaqlService.evaluate("if (\$1.isNull == false) \$1.value else 0", Type.TYPE_NUMBER(), ['1': Value.VALUE_NUMBER(1)], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_NUMBER(1) )
 	}
 	
 }

--- a/test/integration/org/chai/kevin/JaqlServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/JaqlServiceSpec.groovy
@@ -29,9 +29,9 @@ class JaqlServiceSpec extends IntegrationTests {
 	def "evaluate with null values"() {
 		
 		expect:
-		jaqlService.evaluate("\$1.isNull == true", Type.TYPE_BOOL(), ['1': Value.NULL_INSTANCE()], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_BOOL(true) )
-		jaqlService.evaluate("\$1.isNull == false", Type.TYPE_BOOL(), ['1': Value.NULL_INSTANCE()], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_BOOL(false) )
-		jaqlService.evaluate("if (\$1.isNull == false) \$1.value else 0", Type.TYPE_NUMBER(), ['1': Value.VALUE_NUMBER(1)], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_NUMBER(1) )
+		jaqlService.evaluate("\$1 == \"null\"", Type.TYPE_BOOL(), ['1': Value.NULL_INSTANCE()], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_BOOL(true) )
+		jaqlService.evaluate("\$1 != \"null\"", Type.TYPE_BOOL(), ['1': Value.NULL_INSTANCE()], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_BOOL(false) )
+		jaqlService.evaluate("if (\$1 == \"null\") 0 else \$1", Type.TYPE_NUMBER(), ['1': Value.VALUE_NUMBER(1)], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_NUMBER(1) )
 	}
 	
 }

--- a/test/integration/org/chai/kevin/JaqlServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/JaqlServiceSpec.groovy
@@ -1,7 +1,7 @@
 package org.chai.kevin;
 
 import org.chai.kevin.value.Value;
-
+import org.chai.kevin.data.Type;
 import com.ibm.jaql.json.type.JsonValue;
 
 class JaqlServiceSpec extends IntegrationTests {
@@ -26,4 +26,12 @@ class JaqlServiceSpec extends IntegrationTests {
 		thrown IllegalArgumentException
 	}
 		
+	def "evaluate with null values"() {
+		
+		expect:
+		jaqlService.evaluate("\$1.isNull == true", Type.TYPE_BOOL(), ['1': Value.NULL_INSTANCE()], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_BOOL(true) )
+		jaqlService.evaluate("\$1.isNull == false", Type.TYPE_BOOL(), ['1': Value.NULL_INSTANCE()], ['1': Type.TYPE_NUMBER()]).equals( Value.VALUE_BOOL(false) )
+		
+	}
+	
 }

--- a/test/integration/org/chai/kevin/value/ExpressionServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/value/ExpressionServiceSpec.groovy
@@ -100,7 +100,7 @@ public class ExpressionServiceSpec extends IntegrationTests {
 		
 		then:
 		result.value == Value.NULL_INSTANCE()
-		result.status == Status.ERROR
+		result.status == Status.VALID
 	}
 	
 	def "test normalized data element with typing errors"() {

--- a/test/unit/org/chai/kevin/TypeUnitSpec.groovy
+++ b/test/unit/org/chai/kevin/TypeUnitSpec.groovy
@@ -244,7 +244,7 @@ public class TypeUnitSpec extends UnitSpec {
 		type = Type.TYPE_NUMBER()
 		
 		then:
-		type.getJaqlValue(value) == "{\"isNull\":true}";
+		type.getJaqlValue(value) == "\"null\"";
 		
 		when:
 		value = new Value("{\"value\": \"10-02-2009\"}")
@@ -258,7 +258,7 @@ public class TypeUnitSpec extends UnitSpec {
 		type = new Type("{\"type\":\"list\", \"list_type\":{\"type\":\"number\"}}");
 		
 		then:
-		type.getJaqlValue(value) == "[10.0,{\"isNull\":true},]";
+		type.getJaqlValue(value) == "[10.0,\"null\",]";
 		
 	}
 
@@ -399,7 +399,7 @@ public class TypeUnitSpec extends UnitSpec {
 		value = Value.NULL_INSTANCE()
 		
 		then:
-		type.getJaqlValue(value) == "{\"isNull\":true}"
+		type.getJaqlValue(value) == "\"null\""
 		type.getValueFromJaql(type.getJaqlValue(value)).isNull()
 		
 		where:

--- a/test/unit/org/chai/kevin/TypeUnitSpec.groovy
+++ b/test/unit/org/chai/kevin/TypeUnitSpec.groovy
@@ -244,7 +244,7 @@ public class TypeUnitSpec extends UnitSpec {
 		type = Type.TYPE_NUMBER()
 		
 		then:
-		type.getJaqlValue(value) == "null";
+		type.getJaqlValue(value) == "{\"isNull\":true}";
 		
 		when:
 		value = new Value("{\"value\": \"10-02-2009\"}")
@@ -252,6 +252,13 @@ public class TypeUnitSpec extends UnitSpec {
 		
 		then:
 		type.getJaqlValue(value) == "\"10-02-2009\""
+		
+		when:
+		value = new Value("{\"value\": [{\"value\":10}, {\"value\":null}]}")
+		type = new Type("{\"type\":\"list\", \"list_type\":{\"type\":\"number\"}}");
+		
+		then:
+		type.getJaqlValue(value) == "[10.0,{\"isNull\":true},]";
 		
 	}
 
@@ -392,7 +399,7 @@ public class TypeUnitSpec extends UnitSpec {
 		value = Value.NULL_INSTANCE()
 		
 		then:
-		type.getJaqlValue(value) == "null"
+		type.getJaqlValue(value) == "{\"isNull\":true}"
 		type.getValueFromJaql(type.getJaqlValue(value)).isNull()
 		
 		where:


### PR DESCRIPTION
I know this is not great because can conflict with someone actually entering "null" in a field but it's a good workaround since the Java JAQL library doesn't seem to support null json values
