### PR TITLE
Fct filter bar chart locations

### DIFF
--- a/grails-app/controllers/org/chai/kevin/fct/FctController.groovy
+++ b/grails-app/controllers/org/chai/kevin/fct/FctController.groovy
@@ -4,6 +4,7 @@ import org.chai.kevin.AbstractController
 import org.chai.kevin.Period
 import org.chai.kevin.location.DataLocationType
 import org.chai.kevin.location.Location
+import org.chai.kevin.location.LocationLevel
 import org.chai.kevin.reports.ReportProgram
 import org.chai.kevin.reports.ReportService
 
@@ -56,14 +57,14 @@ class FctController extends AbstractController {
 		Location location = getLocation()
 		Set<DataLocationType> dataLocationTypes = getLocationTypes()
 
-//		LocationLevel level = getLevel()
 		FctTarget fctTarget = getFctTarget(program)			
 		def skipLevels = fctService.getSkipLocationLevels()
 		def locationTree = location.collectTreeWithDataLocations(skipLevels, dataLocationTypes).asList()
+		LocationLevel level = locationService.getLevelAfter(location.getLevel(), skipLevels)
 		
 		FctTable fctTable = null;
 		if (period != null && program != null && fctTarget != null && location != null && dataLocationTypes != null) {					
-			fctTable = fctService.getFctTable(location, program, fctTarget, period, null, dataLocationTypes);
+			fctTable = fctService.getFctTable(location, program, fctTarget, period, level, dataLocationTypes);
 		}
 		
 		if (log.isDebugEnabled()) log.debug('fct: '+fctTable+" root program: "+program)				
@@ -75,11 +76,11 @@ class FctController extends AbstractController {
 			selectedTargetClass: FctTarget.class,
 			currentLocation: location,
 			locationTree: locationTree,
-//			currentLevel: level,
 			currentLocationTypes: dataLocationTypes,
 			currentTarget: fctTarget,
 			fctTargets: getFctTargets(program),		
-			skipLevels: skipLevels
+			skipLevels: skipLevels,
+			currentChildLevel: level
 		]
 	}
 }

--- a/grails-app/services/org/chai/kevin/LocationService.groovy
+++ b/grails-app/services/org/chai/kevin/LocationService.groovy
@@ -142,20 +142,39 @@ public class LocationService {
 		criteria.add(textRestrictions)
 		return criteria
 	}
+	
 	// TODO property of level?
-	public LocationLevel getLevelBefore(LocationLevel level) {
+	public LocationLevel getLevelBefore(LocationLevel level, Set<LocationLevel> skipLevels) {
 		List<LocationLevel> levels = listLevels();
 		Integer intLevel = levels.indexOf(level);
-		if (intLevel-1 >= 0) return levels.get(levels.indexOf(level)-1);
-		else return null;
+		if(skipLevels != null){
+			List<Integer> intSkipLevels = new ArrayList<Integer>();
+			for(LocationLevel skipLevel : skipLevels)
+				intSkipLevels.add(levels.indexOf(skipLevel));
+			while(intLevel-1 >= 0 && intSkipLevels.contains(intLevel-1)){
+				intLevel--;
+			}
+		}
+		if (intLevel-1 >= 0) 
+			return levels.get(intLevel-1);
+		else return null;		
 	}
 	
 	// TODO property of level?	
-	public LocationLevel getLevelAfter(LocationLevel level) {
+	public LocationLevel getLevelAfter(LocationLevel level, Set<LocationLevel> skipLevels) {
 		List<LocationLevel> levels = listLevels();
 		Integer intLevel = levels.indexOf(level);
-		if (intLevel+1 < levels.size()) return levels.get(levels.indexOf(level)+1);
-		else return null;
+		if(skipLevels != null){
+			List<Integer> intSkipLevels = new ArrayList<Integer>();
+			for(LocationLevel skipLevel : skipLevels)
+				intSkipLevels.add(levels.indexOf(skipLevel));
+			while(intLevel+1 < levels.size() && intSkipLevels.contains(intLevel+1)){
+				intLevel++;
+			}
+		}
+		if (intLevel+1 < levels.size())
+			return levels.get(intLevel+1);
+		else return null;		
 	}
 	
 	// TODO move to location

--- a/grails-app/views/fct/_reportLocationBarChart.gsp
+++ b/grails-app/views/fct/_reportLocationBarChart.gsp
@@ -10,30 +10,34 @@
 		<tr>
 			<g:if test="${fctTable != null && fctTable.locations != null && !fctTable.locations.empty}">
 				<g:each in="${fctTable.locations}" var="location">
-					<td>
-						<g:if test="${fctTable != null && fctTable.targetOptions != null && !fctTable.targetOptions.empty}">
-							<g:each in="${fctTable.targetOptions}" var="targetOption" status="i">
-								<g:if test="${fctTable.getReportValue(location, targetOption) != null}">
-									<g:set var="reportValue" value="${fctTable.getReportValue(location, targetOption).value}" />
-									<div class="js_bar_vertical tooltip bar${i+1}"
-										data-percentage="${reportValue}" title="${reportValue}%"
-										style="height: ${reportValue}%;"></div>
-								</g:if>
-								<g:else>
-									<div class="js_bar_vertical tooltip bar${i+1}"
-										data-percentage="N/A" title="${message(code:'fct.report.table.na')}" 
-										style="height: 0%;"></div>
-								</g:else>
-							</g:each>
-						</g:if>
-					</td>
+					<g:if test="${location == currentLocation || location.level.id == currentChildLevel.id}">
+						<td>
+							<g:if test="${fctTable != null && fctTable.targetOptions != null && !fctTable.targetOptions.empty}">
+								<g:each in="${fctTable.targetOptions}" var="targetOption" status="i">
+									<g:if test="${fctTable.getReportValue(location, targetOption) != null}">
+										<g:set var="reportValue" value="${fctTable.getReportValue(location, targetOption).value}" />
+										<div class="js_bar_vertical tooltip bar${i+1}"
+											data-percentage="${reportValue}" title="${reportValue}%"
+											style="height: ${reportValue}%;"></div>
+									</g:if>
+									<g:else>
+										<div class="js_bar_vertical tooltip bar${i+1}"
+											data-percentage="N/A" title="${message(code:'fct.report.table.na')}" 
+											style="height: 0%;"></div>
+									</g:else>
+								</g:each>
+							</g:if>
+						</td>
+					</g:if>
 				</g:each>
 			</g:if>				
 		</tr>
 		<tr>
 			<g:if test="${fctTable != null && fctTable.locations != null && !fctTable.locations.empty}">
 				<g:each in="${fctTable.locations}" var="location">
-					<td><g:i18n field="${location.names}" /></td>
+					<g:if test="${location == currentLocation || location.level.id == currentChildLevel.id}">
+						<td><g:i18n field="${location.names}" /></td>
+					</g:if>
 				</g:each>
 			</g:if>
 		</tr>

--- a/test/integration/org/chai/kevin/FilterTagLibSpec.groovy
+++ b/test/integration/org/chai/kevin/FilterTagLibSpec.groovy
@@ -9,7 +9,7 @@ class FilterTagLibSpec extends IntegrationTests {
 
 	def filterTagLib	
 	
-	def "location sets missing level"() {
+	def "location sets missing level with null skip levels"() {
 		setup:
 		setupLocationTree()
 		filterTagLib = new FilterTagLib()
@@ -18,8 +18,78 @@ class FilterTagLibSpec extends IntegrationTests {
 		filterTagLib.createLinkByFilter([
 			controller:'controller',
 			action:'action',
-			params: [location: Location.findByCode(RWANDA).id+'', filter: 'location']
-		], null) == "/controller/action?level="+LocationLevel.findByCode(PROVINCE).id+"&location="+Location.findByCode(RWANDA).id+"&filter=location"
+			params: [location:Location.findByCode(RWANDA).id+'',filter: 'location'],
+			skipLevels: null], null) == 
+		"/controller/action?level="+LocationLevel.findByCode(PROVINCE).id+"&location="+Location.findByCode(RWANDA).id+"&filter=location"
 	}
-
+	
+	def "location sets missing level unaffected by skip levels"() {
+		setup:
+		setupLocationTree()
+		filterTagLib = new FilterTagLib()
+		
+		expect:		
+		filterTagLib.createLinkByFilter([
+			controller:'controller',
+			action:'action',
+			params: [location:Location.findByCode(RWANDA).id+'', filter:'location'],
+			skipLevels: new HashSet([LocationLevel.findByCode(SECTOR)])], null) == 
+		"/controller/action?level="+LocationLevel.findByCode(PROVINCE).id+"&location="+Location.findByCode(RWANDA).id+"&filter=location"
+	}
+	
+	def "location sets level with skip levels"() {
+		setup:
+		setupLocationTree()
+		filterTagLib = new FilterTagLib()
+		
+		expect:
+		filterTagLib.createLinkByFilter([
+			controller:'controller',
+			action:'action',
+			params: [location:Location.findByCode(RWANDA).id+'', level:LocationLevel.findByCode(COUNTRY).id+'', filter: 'location'],
+			skipLevels: new HashSet([LocationLevel.findByCode(PROVINCE)])], null) == 
+		"/controller/action?level="+LocationLevel.findByCode(DISTRICT).id+"&location="+Location.findByCode(RWANDA).id+"&filter=location"
+	}
+	
+	def "level does not set missing location with null skip levels"() {
+		setup:
+		setupLocationTree()
+		filterTagLib = new FilterTagLib()
+				
+		expect:
+		filterTagLib.createLinkByFilter([
+			controller:'controller',
+			action:'action',
+			params: [level:LocationLevel.findByCode(PROVINCE).id+'', filter:'level'],
+			skipLevels: null], null) == 
+		"/controller/action?level="+LocationLevel.findByCode(PROVINCE).id+"&filter=level"		
+	}
+	
+	def "level does not set missing location unaffected by skip levels"() {
+		setup:
+		setupLocationTree()
+		filterTagLib = new FilterTagLib()
+		
+		expect:
+		filterTagLib.createLinkByFilter([
+			controller:'controller',
+			action:'action',
+			params: [level:LocationLevel.findByCode(PROVINCE).id+'', filter:'level'],
+			skipLevels: new HashSet([LocationLevel.findByCode(SECTOR)])], null) == 
+		"/controller/action?level="+LocationLevel.findByCode(PROVINCE).id+"&filter=level"
+	}
+	
+	def "level sets location with skip levels"() {
+		setup:
+		setupLocationTree()
+		filterTagLib = new FilterTagLib()
+		
+		expect:
+		filterTagLib.createLinkByFilter([
+			controller:'controller',
+			action:'action',
+			params: [location:Location.findByCode(BURERA).id+'', level:LocationLevel.findByCode(DISTRICT).id+'', filter:'level'],
+			skipLevels: new HashSet([LocationLevel.findByCode(PROVINCE)])], null) == 
+		"/controller/action?level="+LocationLevel.findByCode(DISTRICT).id+"&location="+Location.findByCode(RWANDA).id+"&filter=level"
+	}
 }

--- a/test/integration/org/chai/kevin/fct/FctControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/fct/FctControllerSpec.groovy
@@ -24,7 +24,7 @@ class FctControllerSpec extends FctIntegrationTests {
 		fctController.params.period = period.id
 		fctController.params.location = Location.findByCode(RWANDA).id
 		fctController.params.program = program.id		
-//		fctController.params.level = LocationLevel.findByCode(DISTRICT).id
+		fctController.params.level = LocationLevel.findByCode(PROVINCE).id
 		fctController.params.fctTarget = target.id
 		def model = fctController.view()
 		
@@ -32,7 +32,7 @@ class FctControllerSpec extends FctIntegrationTests {
 		model.currentPeriod.equals(period)
 		model.currentLocation.equals(Location.findByCode(RWANDA))
 		model.currentProgram.equals(program)
-//		model.currentLevel.equals(LocationLevel.findByCode(DISTRICT))
+		model.currentChildLevel.equals(LocationLevel.findByCode(PROVINCE))
 		model.currentTarget.equals(target)
 		model.fctTable != null		
 		model.fctTable.valueMap.isEmpty() == false
@@ -51,7 +51,7 @@ class FctControllerSpec extends FctIntegrationTests {
 		when: "no program"
 		fctController = new FctController()
 		fctController.params.period = period.id
-//		fctController.params.level = 3
+		fctController.params.level = LocationLevel.findByCode(PROVINCE).id
 		fctController.params.fctTarget = target.id
 		def model = fctController.view()
 		
@@ -72,6 +72,7 @@ class FctControllerSpec extends FctIntegrationTests {
 		fctController = new FctController()
 		fctController.params.period = period.id
 		fctController.params.location = Location.findByCode(BURERA).id
+		fctController.params.level = LocationLevel.findByCode(SECTOR).id
 		fctController.params.program = program.id
 		def model = fctController.view()
 		
@@ -91,6 +92,7 @@ class FctControllerSpec extends FctIntegrationTests {
 		fctController = new FctController()
 		fctController.params.period = period.id
 		fctController.params.location = Location.findByCode(BURERA).id
+		fctController.params.level = LocationLevel.findByCode(SECTOR).id
 		fctController.params.program = program.id
 		def model = fctController.view()
 		
@@ -113,7 +115,49 @@ class FctControllerSpec extends FctIntegrationTests {
 		def model = fctController.view()
 		
 		then:
-		model.currentProgram.id == program.id
+		model.currentProgram.equals(program)
+		model.fctTable != null
+		model.fctTable.hasData() == true
+	}
+	
+	def "get fct with invalid location (and level) parameter"() {
+		setup:
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(CODE(2))
+		def sum = newSum("1", CODE(2))
+		def target = newFctTarget(CODE(3), sum, [DISTRICT_HOSPITAL_GROUP, HEALTH_CENTER_GROUP], program)
+		def targetOption1 = newFctTargetOption(CODE(4), target, sum, 1)
+		
+		when:
+		fctController = new FctController()
+		fctController.params.location = Location.findByCode(BURERA).id+1
+		def model = fctController.view()
+		
+		then:
+		model.currentLocation.equals(Location.findByCode(RWANDA))
+		model.currentChildLevel.equals(LocationLevel.findByCode(PROVINCE)) 
+		model.fctTable != null
+		model.fctTable.hasData() == true
+	}
+	
+	def "get fct with skipped level parameter"() {
+		setup:
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(CODE(2))
+		def sum = newSum("1", CODE(2))
+		def target = newFctTarget(CODE(3), sum, [DISTRICT_HOSPITAL_GROUP, HEALTH_CENTER_GROUP], program)
+		def targetOption1 = newFctTargetOption(CODE(4), target, sum, 1)
+		
+		when:
+		fctController = new FctController()
+		fctController.params.location = Location.findByCode(BURERA).id
+		def model = fctController.view()
+		
+		then:
+		model.currentLocation.equals(Location.findByCode(BURERA))
+		model.currentChildLevel.equals(null)
 		model.fctTable != null
 		model.fctTable.hasData() == true
 	}

--- a/test/integration/org/chai/kevin/fct/FctServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/fct/FctServiceSpec.groovy
@@ -9,6 +9,7 @@ import org.chai.kevin.location.LocationLevel;
 class FctServiceSpec extends FctIntegrationTests { 
 
 	def fctService
+	def locationService
 	
 	def "test normal fct service"() {
 		setup:
@@ -19,20 +20,21 @@ class FctServiceSpec extends FctIntegrationTests {
 		def sum = newSum("\$"+normalizedDataElement.id, CODE(2))
 		def target = newFctTarget(CODE(3), sum, [DISTRICT_HOSPITAL_GROUP, HEALTH_CENTER_GROUP], program)
 		def targetOption = newFctTargetOption(CODE(4), target, sum, 1)
-//		def level = LocationLevel.findByCode(DISTRICT)
+		def location = Location.findByCode(RWANDA)
+		def level = locationService.getLevelAfter(location.getLevel(), new HashSet([LocationLevel.findByCode(SECTOR)]))
 		def dataLocationTypes = new HashSet([DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP), DataLocationType.findByCode(HEALTH_CENTER_GROUP)])
 		def fctTable = null
 		refresh()
 		
 		when:
-		fctTable = fctService.getFctTable(Location.findByCode(RWANDA), program, target, period, null, dataLocationTypes)
+		fctTable = fctService.getFctTable(location, program, target, period, level, dataLocationTypes)
 		
 		then:
 		fctTable.getReportValue(Location.findByCode(NORTH), targetOption).value == "2.0"
 		
 		when:
 		dataLocationTypes = new HashSet([DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP)])
-		fctTable = fctService.getFctTable(Location.findByCode(RWANDA), program, target, period, null, dataLocationTypes)
+		fctTable = fctService.getFctTable(location, program, target, period, level, dataLocationTypes)
 		
 		then:
 		fctTable.getReportValue(Location.findByCode(NORTH), targetOption).value == "1.0"
@@ -47,14 +49,15 @@ class FctServiceSpec extends FctIntegrationTests {
 		def sum = newSum("\$"+normalizedDataElement.id, CODE(2))
 		def target = newFctTarget(CODE(3), sum, [DISTRICT_HOSPITAL_GROUP, HEALTH_CENTER_GROUP], program)
 		def targetOption = newFctTargetOption(CODE(4), target, sum, 1)
-		def level = LocationLevel.findByCode(PROVINCE)
+		def location = Location.findByCode(RWANDA)
+		def level = locationService.getLevelAfter(location.getLevel(), new HashSet([LocationLevel.findByCode(SECTOR)]))
 		def dataLocationTypes = new HashSet([DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP), DataLocationType.findByCode(HEALTH_CENTER_GROUP)])
 		def fctTable = null
 		
 		when:
-		def dummy = newLocation("dummy", Location.findByCode(RWANDA), level)
+		def dummy = newLocation("dummy", location, level)
 		refresh()
-		fctTable = fctService.getFctTable(Location.findByCode(RWANDA), program, target, period, null, dataLocationTypes)
+		fctTable = fctService.getFctTable(location, program, target, period, level, dataLocationTypes)
 		
 		then:
 		fctTable.getReportValue(Location.findByCode("dummy"), targetOption) == null

--- a/test/integration/org/chai/kevin/location/LocationServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/location/LocationServiceSpec.groovy
@@ -155,4 +155,68 @@ class LocationServiceSpec extends IntegrationTests {
 		levels != noSkipLevels
 		levels.size() == 3
 	}
+	
+	def "get level before with skip levels"(){
+		setup:
+		setupLocationTree()
+		
+		//levelBefore == null
+		when:
+		def level = LocationLevel.findByCode(PROVINCE)
+		def skipLevels = new HashSet([LocationLevel.findByCode(COUNTRY)])
+		def levelBefore = locationService.getLevelBefore(level, skipLevels)		
+		
+		then:
+		levelBefore == null
+		
+		//levelBefore skips 1 level
+		when:
+		level = LocationLevel.findByCode(DISTRICT)
+		skipLevels = new HashSet([LocationLevel.findByCode(PROVINCE)])
+		levelBefore = locationService.getLevelBefore(level, skipLevels)
+		
+		then:
+		levelBefore.equals(LocationLevel.findByCode(COUNTRY))
+		
+		//levelBefore skips 2 levels
+		when:
+		level = LocationLevel.findByCode(SECTOR)
+		skipLevels = new HashSet([LocationLevel.findByCode(PROVINCE), LocationLevel.findByCode(DISTRICT)])
+		levelBefore = locationService.getLevelBefore(level, skipLevels)
+		
+		then:
+		levelBefore.equals(LocationLevel.findByCode(COUNTRY))
+	}
+	
+	def "get level after with skip levels"(){
+		setup:
+		setupLocationTree()
+		
+		//levelAfter == null
+		when:
+		def level = LocationLevel.findByCode(DISTRICT)
+		def skipLevels = new HashSet([LocationLevel.findByCode(SECTOR)])
+		def levelAfter = locationService.getLevelAfter(level, skipLevels)
+		
+		then:
+		levelAfter == null
+		
+		//levelAfter skips 1 level
+		when:
+		level = LocationLevel.findByCode(PROVINCE)
+		skipLevels = new HashSet([LocationLevel.findByCode(DISTRICT)])
+		levelAfter = locationService.getLevelAfter(level, skipLevels)
+		
+		then:
+		levelAfter.equals(LocationLevel.findByCode(SECTOR))
+		
+		//levelAfter skips 2 levels
+		when:
+		level = LocationLevel.findByCode(COUNTRY)
+		skipLevels = new HashSet([LocationLevel.findByCode(PROVINCE), LocationLevel.findByCode(DISTRICT)])
+		levelAfter = locationService.getLevelAfter(level, skipLevels)
+		
+		then:
+		levelAfter.equals(LocationLevel.findByCode(SECTOR))
+	}
 }

--- a/test/unit/org/chai/kevin/location/CalculationLocationUnitSpec.groovy
+++ b/test/unit/org/chai/kevin/location/CalculationLocationUnitSpec.groovy
@@ -241,9 +241,9 @@ class CalculationLocationUnitSpec extends UnitSpec {
 		def data2 = new DataLocation(code: 'data2', location: burera, type: type2)
 		
 		rwanda.children = [north, south]
-		rwanda.dataLocationEntities = [data1]
+		rwanda.dataLocations = [data1]
 		north.children = [burera]
-		burera.dataLocationEntities = [data2]
+		burera.dataLocations = [data2]
 		
 		then:
 		rwanda.getChildrenEntitiesWithDataLocations(null, types).equals([north, data1])


### PR DESCRIPTION
1. filtered bar chart to only display current location's children, 
2. updated usage of Location methods getLevelBefore and getLevelAfter to include skipLevels,
3. updated tests!
