### PR TITLE
modified log info from 'data element' to 'raw data element'

### DIFF
--- a/grails-app/controllers/org/chai/kevin/survey/TableRowController.groovy
+++ b/grails-app/controllers/org/chai/kevin/survey/TableRowController.groovy
@@ -88,9 +88,8 @@ class TableRowController extends AbstractEntityController {
 					if (log.isInfoEnabled()) log.info ("binding SurveyElement "+surveyElement)
 					surveyElement.setSurveyQuestion(entity.question)
 					surveyElement.dataElement = dataElement
-					if (log.isInfoEnabled()) log.info ("binding dataElement "+dataElement)
+					if (log.isInfoEnabled()) log.info ("binding RawDataElement "+dataElement)
 					entity.surveyElements[column] = surveyElement
-					
 				}
 			}
 		}


### PR DESCRIPTION
http://www.districthealth.moh.gov.rw/tableRow/create?targetURI=%2FtableQuestion%2Fedit%3Fid%3D480%26targetURI%3D%252Fquestion%252Flist%253Fsection.id%253D65&question.id=480
http://gyazo.com/d2c0b9a5b0e25c56047707f56fb476dc

http://www.districthealth.moh.gov.rw/tableRow/save?targetURI=%2FtableQuestion%2Fedit%3Fid%3D480%26targetURI%3D%252Fquestion%252Flist%253Fsection.id%253D65
http://gyazo.com/eed542475e8aa233ce4178ae8479b1b1

Creating a row (first 2 links) results in a SQLException (second 2 links)

The only objects that contain 'jsonDescriptions' are the SurveyTableQuestion -> SurveyQuestion base class -> Translation descriptions member, and the SurveyElement -> FormElement -> RawDataElement dataElement member -> DataElement -> Data base class -> Translation descriptions member. 

For this question, there is 'Question' text for the SurveyTableQuestion's description, and there is 'Description' text for the RawDataElement's description, i.e. both descriptions are not null when the SurveyTableRow is saved.
