### PR TITLE
missing values are now treated as null values

### DIFF
--- a/grails-app/services/org/chai/kevin/value/ExpressionService.java
+++ b/grails-app/services/org/chai/kevin/value/ExpressionService.java
@@ -144,27 +144,22 @@ public class ExpressionService {
 				
 				for (Entry<String, T> entry : datas.entrySet()) {
 					DataValue dataValue = valueService.getDataElementValue(entry.getValue(), dataLocation, period);
-					valueMap.put(entry.getValue().getId().toString(), dataValue==null?null:dataValue.getValue());
+					Value value = dataValue==null?null:dataValue.getValue();
+					if (value == null) value = Value.NULL_INSTANCE();
+					valueMap.put(entry.getValue().getId().toString(), value);
 					typeMap.put(entry.getValue().getId().toString(), entry.getValue().getType());
 				}
 //				if (expressionLog.isDebugEnabled()) expressionLog.debug("values and types: valueMap={"+valueMap+"}", typeMap={"+typeMap+"}");
 				
-				if (hasNullValues(valueMap.values())) {
-					if (expressionLog.isInfoEnabled()) expressionLog.info("found null values");
+				try {
+					if (expressionLog.isInfoEnabled()) expressionLog.info("no null values found, evaluating expression");
+					statusValuePair.value = jaqlService.evaluate(expression, type, valueMap, typeMap);
+					statusValuePair.status = Status.VALID;
+				} catch (IllegalArgumentException e) {
+					if (expressionLog.isErrorEnabled()) expressionLog.error("expression={"+expression+"}, type={"+type+"}, period={"+period+"}, dataLocation={"+dataLocation+"}, valueMap={"+valueMap+"}, typeMap={"+typeMap+"}", e);
+					log.warn("there was an error evaluating expression: "+expression, e);
 					statusValuePair.value = Value.NULL_INSTANCE();
-					statusValuePair.status = Status.MISSING_VALUE;
-				}
-				else {
-					try {
-						if (expressionLog.isInfoEnabled()) expressionLog.info("no null values found, evaluating expression");
-						statusValuePair.value = jaqlService.evaluate(expression, type, valueMap, typeMap);
-						statusValuePair.status = Status.VALID;
-					} catch (IllegalArgumentException e) {
-						if (expressionLog.isErrorEnabled()) expressionLog.error("expression={"+expression+"}, type={"+type+"}, period={"+period+"}, dataLocation={"+dataLocation+"}, valueMap={"+valueMap+"}, typeMap={"+typeMap+"}", e);
-						log.warn("there was an error evaluating expression: "+expression, e);
-						statusValuePair.value = Value.NULL_INSTANCE();
-						statusValuePair.status = Status.ERROR;
-					}
+					statusValuePair.status = Status.ERROR;
 				}
 			}
 		}

--- a/src/java/org/chai/kevin/value/Status.java
+++ b/src/java/org/chai/kevin/value/Status.java
@@ -2,7 +2,6 @@ package org.chai.kevin.value;
 
 public enum Status {
 	VALID, // OK
-	MISSING_VALUE, // value is missing
 	MISSING_EXPRESSION, // expression is missing for period or data location type
 	MISSING_DATA_ELEMENT, // referenced data element in expression is missing
 	ERROR // other error (typing, jaql error)

--- a/test/integration/org/chai/kevin/data/DataControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/data/DataControllerSpec.groovy
@@ -90,7 +90,7 @@ class DataControllerSpec extends IntegrationTests {
 		dataController.modelAndView.model.entities.equals([(period1):[]])
 		
 		when:
-		def dataElementValue = newNormalizedDataElementValue(dataElement, DataLocation.findByCode(BUTARO), period1, Status.MISSING_VALUE, Value.NULL_INSTANCE())
+		def dataElementValue = newNormalizedDataElementValue(dataElement, DataLocation.findByCode(BUTARO), period1, Status.VALID, Value.NULL_INSTANCE())
 		dataController.dataElementValueList()
 		
 		then:

--- a/test/integration/org/chai/kevin/value/ExpressionServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/value/ExpressionServiceSpec.groovy
@@ -75,7 +75,7 @@ public class ExpressionServiceSpec extends IntegrationTests {
 		
 		then:
 		result.value == Value.NULL_INSTANCE()
-		result.status == Status.MISSING_VALUE
+		result.status == Status.VALID
 
 		when: "expression is missing for data location type"
 		result = expressionService.calculateValue(normalizedDataElement, DataLocation.findByCode(KIVUYE), period)
@@ -101,6 +101,28 @@ public class ExpressionServiceSpec extends IntegrationTests {
 		then:
 		result.value == Value.NULL_INSTANCE()
 		result.status == Status.VALID
+	}
+	
+	def "test check for null in formulas"() {
+		setup:
+		setupLocationTree()
+		def period = newPeriod()
+		def dataElement = newRawDataElement(CODE(1), Type.TYPE_NUMBER())
+		def normalizedDataElement = newNormalizedDataElement(CODE(2), Type.TYPE_NUMBER(), e([(period.id+''):[(DISTRICT_HOSPITAL_GROUP):"if (\$"+dataElement.id+" == \"null\") 1 else 0"]]))
+		def result
+		
+		when: "value is missing"
+		result = expressionService.calculateValue(normalizedDataElement, DataLocation.findByCode(BUTARO), period)
+		
+		then:
+		result.value == Value.VALUE_NUMBER(1);
+		
+		when: "value is null"
+		newRawDataElementValue(dataElement, period, DataLocation.findByCode(BUTARO), Value.NULL_INSTANCE())
+		result = expressionService.calculateValue(normalizedDataElement, DataLocation.findByCode(BUTARO), period)
+		
+		then:
+		result.value == Value.VALUE_NUMBER(1);
 	}
 	
 	def "test normalized data elements expression empty expressions treated as missing"() {


### PR DESCRIPTION
before this patch, when an expression in a NDE referenced a missing value, the expression was not evaluated and the NDE value was automatically set to null. 

this prevents writing an expression that checks for null values and returns (for example) an empty list in that case. to be able to test against null values in formulas, we just pass null and evaluate the formula nevertheless when a RDEValue is missing.
