### PR TITLE
Dsr target add calculation or dataelement

### DIFF
--- a/grails-app/controllers/org/chai/kevin/dsr/DsrTargetController.groovy
+++ b/grails-app/controllers/org/chai/kevin/dsr/DsrTargetController.groovy
@@ -69,7 +69,7 @@ class DsrTargetController extends AbstractEntityController {
 			programs: ReportProgram.list(),
 			categories: DsrTargetCategory.list(),
 //			dataElements: entity.dataElement!=null?[entity.dataElement]:[],
-			calculationElements: entity.calculationElement!=null?[entity.calculationElement]:[]
+			data: entity.data!=null?[entity.data]:[]
 		]
 	}
 
@@ -88,7 +88,7 @@ class DsrTargetController extends AbstractEntityController {
 	def bindParams(def entity) {
 		bindData(entity, params, [exclude:'dataElement.id'])
 //		if (params.int('dataElement.id')) entity.dataElement = dataService.getData(params.int('dataElement.id'), DataElement.class)
-		if (params.int('calculationElement.id')) entity.calculationElement = dataService.getData(params.int('calculationElement.id'), Data.class)
+		if (params.int('data.id')) entity.data = dataService.getData(params.int('data.id'), Data.class)
 		
 		// FIXME GRAILS-6967 makes this necessary
 		// http://jira.grails.org/browse/GRAILS-6967

--- a/grails-app/controllers/org/chai/kevin/dsr/DsrTargetController.groovy
+++ b/grails-app/controllers/org/chai/kevin/dsr/DsrTargetController.groovy
@@ -34,6 +34,8 @@ package org.chai.kevin.dsr;
  */
 
 import grails.plugin.springcache.annotations.CacheFlush
+import org.chai.kevin.data.Calculation;
+import org.chai.kevin.data.Data;
 import org.chai.kevin.data.DataElement;
 import org.chai.kevin.location.DataLocationType;
 import org.chai.kevin.reports.ReportProgram;
@@ -66,7 +68,8 @@ class DsrTargetController extends AbstractEntityController {
 			target: entity,
 			programs: ReportProgram.list(),
 			categories: DsrTargetCategory.list(),
-			dataElements: entity.dataElement!=null?[entity.dataElement]:[]
+//			dataElements: entity.dataElement!=null?[entity.dataElement]:[],
+			calculationElements: entity.calculationElement!=null?[entity.calculationElement]:[]
 		]
 	}
 
@@ -84,8 +87,9 @@ class DsrTargetController extends AbstractEntityController {
 
 	def bindParams(def entity) {
 		bindData(entity, params, [exclude:'dataElement.id'])
-		if (params.int('dataElement.id')) entity.dataElement = dataService.getData(params.int('dataElement.id'), DataElement.class)
-
+//		if (params.int('dataElement.id')) entity.dataElement = dataService.getData(params.int('dataElement.id'), DataElement.class)
+		if (params.int('calculationElement.id')) entity.calculationElement = dataService.getData(params.int('calculationElement.id'), Data.class)
+		
 		// FIXME GRAILS-6967 makes this necessary
 		// http://jira.grails.org/browse/GRAILS-6967
 		if (params.names!=null) entity.names = params.names

--- a/grails-app/domain/org/chai/kevin/Initializer.groovy
+++ b/grails-app/domain/org/chai/kevin/Initializer.groovy
@@ -897,7 +897,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Accountant"]), descriptions:j(["en":"Accountant"]),
 					program: hmr,
-					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
+					data: NormalizedDataElement.findByCode("Constant 10"),
 					order: 8,
 					code: "Accountant"
 					).save(failOnError:true)
@@ -905,7 +905,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Days Of Nurse Training"]), descriptions:j(["en":"Days Of Nurse Training"]),
 					program: hmr,
-					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
+					data: NormalizedDataElement.findByCode("Constant 20"),
 					order: 1,
 					code: "Days Of Nurse Training"
 					).save(failOnError:true)
@@ -913,7 +913,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"A0"]), descriptions:j(["en":"A0"]),
 					program: hmr,
-					calculationElement: RawDataElement.findByCode("CODE1"),
+					data: RawDataElement.findByCode("CODE1"),
 					order: 1,
 					code: "A0"
 					).save(failOnError:true)
@@ -921,7 +921,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"A1"]), descriptions:j(["en":"A1"]),
 					program: hmr,
-					calculationElement: NormalizedDataElement.findByCode("TRUE"),
+					data: NormalizedDataElement.findByCode("TRUE"),
 					order: 2,
 					code: "A1"
 					).save(failOnError:true)
@@ -929,7 +929,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"A2"]), descriptions:j(["en":"A2"]),
 					program: hmr,
-					calculationElement: NormalizedDataElement.findByCode("FALSE"),
+					data: NormalizedDataElement.findByCode("FALSE"),
 					order: 3,
 					code:"A2"
 					).save(failOnError:true)
@@ -937,7 +937,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"A3"]), descriptions:j(["en":"A3"]),
 					program: hmr,
-					calculationElement: dsrAverage,
+					data: dsrAverage,
 					order: 4,
 					code: "A3"
 					).save(failOnError:true)
@@ -945,7 +945,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"A4"]), descriptions:j(["en":"A4"]),
 					program: hmr,
-					calculationElement: dsrSum,
+					data: dsrSum,
 					order: 5,
 					code: "A4"
 					).save(failOnError:true)
@@ -953,7 +953,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Testing Category Human Resource"]), descriptions:j(["en":"Testing Category Human Resource"]),
 					program: hmr,
-					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
+					data: NormalizedDataElement.findByCode("Constant 20"),
 					order: 4,
 					code: "Testing Category Human Resource"
 					).save(failOnError:true)
@@ -961,7 +961,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"In-Facility Birth Ratio"]), descriptions:j(["en":"In-Facility Birth Ratio"]),
 					program: servDeliv,
-					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
+					data: NormalizedDataElement.findByCode("Constant 20"),
 					order: 6,
 					code: "In-Facility Birth Ratio"
 					).save(failOnError:true)
@@ -969,7 +969,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Mental Health Service"]), descriptions:j(["en":"Mental Health Service"]),
 					program: servDeliv,
-					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
+					data: NormalizedDataElement.findByCode("Constant 20"),
 					order: 11,
 					code: "Mental Health Service"
 					).save(failOnError:true)
@@ -977,7 +977,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Malaria Rapid Test"]), descriptions:j(["en":"Malaria Rapid Test"]),
 					program: servDeliv,
-					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
+					data: NormalizedDataElement.findByCode("Constant 20"),
 					order: 7,
 					code: "Malaria Rapid Test"
 					).save(failOnError:true)
@@ -985,7 +985,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"HIV Rapid Test"]), descriptions:j(["en":"HIV Rapid Test"]),
 					program: servDeliv,
-					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
+					data: NormalizedDataElement.findByCode("Constant 10"),
 					order: 9,
 					code: "HIV Rapid Test"
 					).save(failOnError:true)
@@ -993,7 +993,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"TB Stain Test"]), descriptions:j(["en":"TB Stain Test"]),
 					program: servDeliv,
-					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
+					data: NormalizedDataElement.findByCode("Constant 20"),
 					order: 10,
 					code: "TB Stain Test"
 					).save(failOnError:true)
@@ -1001,7 +1001,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Catchment Population per CHW"]), descriptions:j(["en":"Catchment Population per CHW"]),
 					program: servDeliv,
-					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
+					data: NormalizedDataElement.findByCode("Constant 10"),
 					order: 12,
 					code: "Catchment Population per CHW"
 					).save(failOnError:true)
@@ -1009,7 +1009,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Consultation Room"]), descriptions:j(["en":"Consultation Room"]),
 					program: instCap,
-					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
+					data: NormalizedDataElement.findByCode("Constant 10"),
 					order: 1,
 					code: "Consultation Room"
 					).save(failOnError:true)
@@ -1017,7 +1017,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Facility Water Status"]), descriptions:j(["en":"Facility Water Status"]),
 					program: instCap,
-					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
+					data: NormalizedDataElement.findByCode("Constant 10"),
 					order: 3,
 					code: "Facility Water Status"
 					).save(failOnError:true)
@@ -1025,7 +1025,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Incinerator Availability"]), descriptions:j(["en":"Incinerator Availability"]),
 					program: instCap,
-					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
+					data: NormalizedDataElement.findByCode("Constant 10"),
 					order: 2,
 					code: "Incinerator Availability"
 					).save(failOnError:true)
@@ -1033,7 +1033,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Facility Power Status"]), descriptions:j(["en":"Facility Power Status"]),
 					program: instCap,
-					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
+					data: NormalizedDataElement.findByCode("Constant 10"),
 					code: "Facility Power Status"
 					).save(failOnError:true)
 

--- a/grails-app/domain/org/chai/kevin/Initializer.groovy
+++ b/grails-app/domain/org/chai/kevin/Initializer.groovy
@@ -774,7 +774,7 @@ class Initializer {
 					).save(failOnError: true)
 		}
 	}
-
+	
 	static def createDashboard() {
 		if (!DashboardProgram.count()) {
 
@@ -847,51 +847,57 @@ class Initializer {
 			staffing.save(failOnError: true, flush:true)
 		}
 	}
-
+	
 	static def createDsr() {
 		if (!DsrTarget.count()) {
 			def dh = DataLocationType.findByCode("District Hospital")
 			def hc = DataLocationType.findByCode("Health Center")
 
-			def finacss = ReportProgram.findByCode("Service Delivery")
+			def servDeliv = ReportProgram.findByCode("Service Delivery")
 			def instCap = ReportProgram.findByCode("Institutional Capacity")
 			def hmr = ReportProgram.findByCode("Human Resources for Health")
 
 			def root = ReportProgram.findByCode("Strategic Programs")
-			root.addChild(finacss)
+			root.addChild(servDeliv)
 			root.addChild(instCap)
 			root.addChild(hmr)
 			root.save(failOnError: true, flush: true)
 
-			def firstCat1 = new DsrTargetCategory(
+			def infectiousDiseaseCat1 = new DsrTargetCategory(
 					names:j(["en":"Infectious Disease Testing Offered 1"]),
 					order: 1,
 					descriptions:j(["en":"Infectious Disease Testing Offered 1"]),
 					code: "Infectious Disease Testing Offered 1"
 					)
-			def firstCat2 = new DsrTargetCategory(
+			def infectiousDiseaseCat2 = new DsrTargetCategory(
 					names:j(["en":"Infectious Disease Testing Offered 2"]),
 					order: 2,
 					descriptions:j(["en":"Infectious Disease Testing Offered 2"]),
 					code: "Infectious Disease Testing Offered 2"
 					)			
-			def secondCat = new DsrTargetCategory(
+			def nursesCat = new DsrTargetCategory(
 					names:j(["en":"Nurses"]),
 					descriptions:j(["en":"Nurses"]),
 					order: 3,
 					code: "Nurses"
 					)
-			def thirdCat = new DsrTargetCategory(
+			def waterAndPowerCat = new DsrTargetCategory(
 					names:j(["en":"Facility Water and Power Sources"]),
 					order: 2,
 					descriptions:j(["en":"Facility Water and Power Sources"]),
 					code: "Facility Water and Power Sources"
 					)
 
+			def dsrAverage = new Average(expression:"\$"+NormalizedDataElement.findByCode("Constant 10").id, code:"Dsr Average constant 10", timestamp:new Date())
+			dsrAverage.save(failOnError: true)
+			
+			def dsrSum = new Sum(expression: "\$"+NormalizedDataElement.findByCode("Constant 10").id, code:"Dsr Sum constant 10", timestamp:new Date());
+			dsrSum.save(failOnError: true);			
+			
 			new DsrTarget(
 					names:j(["en":"Accountant"]), descriptions:j(["en":"Accountant"]),
 					program: hmr,
-					dataElement: NormalizedDataElement.findByCode("Constant 10"),
+					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
 					order: 8,
 					code: "Accountant"
 					).save(failOnError:true)
@@ -899,15 +905,23 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Days Of Nurse Training"]), descriptions:j(["en":"Days Of Nurse Training"]),
 					program: hmr,
-					dataElement: NormalizedDataElement.findByCode("Constant 20"),
+					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
 					order: 1,
 					code: "Days Of Nurse Training"
 					).save(failOnError:true)
 
 			new DsrTarget(
+					names:j(["en":"A0"]), descriptions:j(["en":"A0"]),
+					program: hmr,
+					calculationElement: RawDataElement.findByCode("CODE1"),
+					order: 1,
+					code: "A0"
+					).save(failOnError:true)
+										
+			new DsrTarget(
 					names:j(["en":"A1"]), descriptions:j(["en":"A1"]),
 					program: hmr,
-					dataElement: NormalizedDataElement.findByCode("TRUE"),
+					calculationElement: NormalizedDataElement.findByCode("TRUE"),
 					order: 2,
 					code: "A1"
 					).save(failOnError:true)
@@ -915,71 +929,79 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"A2"]), descriptions:j(["en":"A2"]),
 					program: hmr,
-					dataElement: NormalizedDataElement.findByCode("FALSE"),
-					order: 5,
+					calculationElement: NormalizedDataElement.findByCode("FALSE"),
+					order: 3,
 					code:"A2"
 					).save(failOnError:true)
 
 			new DsrTarget(
 					names:j(["en":"A3"]), descriptions:j(["en":"A3"]),
 					program: hmr,
-					dataElement: NormalizedDataElement.findByCode("Constant 10"),
-					order: 3,
+					calculationElement: dsrAverage,
+					order: 4,
 					code: "A3"
 					).save(failOnError:true)
 
 			new DsrTarget(
+					names:j(["en":"A4"]), descriptions:j(["en":"A4"]),
+					program: hmr,
+					calculationElement: dsrSum,
+					order: 5,
+					code: "A4"
+					).save(failOnError:true)
+					
+			new DsrTarget(
 					names:j(["en":"Testing Category Human Resource"]), descriptions:j(["en":"Testing Category Human Resource"]),
 					program: hmr,
-					dataElement: NormalizedDataElement.findByCode("Constant 20"),
+					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
 					order: 4,
 					code: "Testing Category Human Resource"
 					).save(failOnError:true)
 
 			new DsrTarget(
 					names:j(["en":"In-Facility Birth Ratio"]), descriptions:j(["en":"In-Facility Birth Ratio"]),
-					program: finacss,
-					dataElement: NormalizedDataElement.findByCode("Constant 20"),
+					program: servDeliv,
+					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
 					order: 6,
 					code: "In-Facility Birth Ratio"
 					).save(failOnError:true)
 
 			new DsrTarget(
 					names:j(["en":"Mental Health Service"]), descriptions:j(["en":"Mental Health Service"]),
-					program: finacss,
-					dataElement: NormalizedDataElement.findByCode("Constant 20"),
+					program: servDeliv,
+					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
 					order: 11,
 					code: "Mental Health Service"
 					).save(failOnError:true)
 
 			new DsrTarget(
 					names:j(["en":"Malaria Rapid Test"]), descriptions:j(["en":"Malaria Rapid Test"]),
-					program: finacss,
-					dataElement: NormalizedDataElement.findByCode("Constant 20"),
+					program: servDeliv,
+					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
 					order: 7,
 					code: "Malaria Rapid Test"
 					).save(failOnError:true)
 
 			new DsrTarget(
 					names:j(["en":"HIV Rapid Test"]), descriptions:j(["en":"HIV Rapid Test"]),
-					program: finacss,
-					dataElement: NormalizedDataElement.findByCode("Constant 10"),
+					program: servDeliv,
+					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
 					order: 9,
 					code: "HIV Rapid Test"
 					).save(failOnError:true)
 
 			new DsrTarget(
 					names:j(["en":"TB Stain Test"]), descriptions:j(["en":"TB Stain Test"]),
-					program: finacss,
-					dataElement: NormalizedDataElement.findByCode("Constant 20"),
+					program: servDeliv,
+					calculationElement: NormalizedDataElement.findByCode("Constant 20"),
 					order: 10,
 					code: "TB Stain Test"
 					).save(failOnError:true)
 
 			new DsrTarget(
 					names:j(["en":"Catchment Population per CHW"]), descriptions:j(["en":"Catchment Population per CHW"]),
-					program: finacss,
-					dataElement: NormalizedDataElement.findByCode("Constant 10"),
+					program: servDeliv,
+					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
 					order: 12,
 					code: "Catchment Population per CHW"
 					).save(failOnError:true)
@@ -987,7 +1009,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Consultation Room"]), descriptions:j(["en":"Consultation Room"]),
 					program: instCap,
-					dataElement: NormalizedDataElement.findByCode("Constant 10"),
+					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
 					order: 1,
 					code: "Consultation Room"
 					).save(failOnError:true)
@@ -995,7 +1017,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Facility Water Status"]), descriptions:j(["en":"Facility Water Status"]),
 					program: instCap,
-					dataElement: NormalizedDataElement.findByCode("Constant 10"),
+					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
 					order: 3,
 					code: "Facility Water Status"
 					).save(failOnError:true)
@@ -1003,7 +1025,7 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Incinerator Availability"]), descriptions:j(["en":"Incinerator Availability"]),
 					program: instCap,
-					dataElement: NormalizedDataElement.findByCode("Constant 10"),
+					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
 					order: 2,
 					code: "Incinerator Availability"
 					).save(failOnError:true)
@@ -1011,26 +1033,28 @@ class Initializer {
 			new DsrTarget(
 					names:j(["en":"Facility Power Status"]), descriptions:j(["en":"Facility Power Status"]),
 					program: instCap,
-					dataElement: NormalizedDataElement.findByCode("Constant 10"),
+					calculationElement: NormalizedDataElement.findByCode("Constant 10"),
 					code: "Facility Power Status"
 					).save(failOnError:true)
 
-			firstCat1.addTarget(DsrTarget.findByCode("Malaria Rapid Test"));
-			firstCat1.addTarget(DsrTarget.findByCode("HIV Rapid Test"));
-			firstCat1.save(failOnError:true);
+			infectiousDiseaseCat1.addTarget(DsrTarget.findByCode("Malaria Rapid Test"));
+			infectiousDiseaseCat1.addTarget(DsrTarget.findByCode("HIV Rapid Test"));
+			infectiousDiseaseCat1.save(failOnError:true);
 			
-			firstCat2.addTarget(DsrTarget.findByCode("Mental Health Service"));
-			firstCat2.addTarget(DsrTarget.findByCode("TB Stain Test"));
-			firstCat2.save(failOnError:true);
+			infectiousDiseaseCat2.addTarget(DsrTarget.findByCode("Mental Health Service"));
+			infectiousDiseaseCat2.addTarget(DsrTarget.findByCode("TB Stain Test"));
+			infectiousDiseaseCat2.save(failOnError:true);
 
-			secondCat.addTarget(DsrTarget.findByCode("A1"));
-			secondCat.addTarget(DsrTarget.findByCode("A2"));
-			secondCat.addTarget(DsrTarget.findByCode("A3"));
-			secondCat.save(failOnError:true);
+			nursesCat.addTarget(DsrTarget.findByCode("A0"));
+			nursesCat.addTarget(DsrTarget.findByCode("A1"));
+			nursesCat.addTarget(DsrTarget.findByCode("A2"));
+			nursesCat.addTarget(DsrTarget.findByCode("A3"));
+			nursesCat.addTarget(DsrTarget.findByCode("A4"));
+			nursesCat.save(failOnError:true);
 
-			thirdCat.addTarget(DsrTarget.findByCode("Facility Water Status"));
-			thirdCat.addTarget(DsrTarget.findByCode("Incinerator Availability"));
-			thirdCat.save(failOnError:true);
+			waterAndPowerCat.addTarget(DsrTarget.findByCode("Facility Water Status"));
+			waterAndPowerCat.addTarget(DsrTarget.findByCode("Incinerator Availability"));
+			waterAndPowerCat.save(failOnError:true);			
 		}
 	}
 
@@ -1113,7 +1137,8 @@ class Initializer {
 			
 			hmr.save(failOnError:true)
 		}
-	}	
+	}
+	
 	
 	static def createPlanning() {
 		
@@ -1354,9 +1379,8 @@ class Initializer {
 				
 		}
 	}
-	
-	
-	
+
+		
 	static def createQuestionaire(){
 		if(!Survey.count()){
 
@@ -2050,6 +2074,7 @@ class Initializer {
 			surveyOne.save()
 		}
 	}
+	
 
 	public static Date getDate( int year, int month, int day ) {
 		final Calendar calendar = Calendar.getInstance();
@@ -2069,7 +2094,7 @@ class Initializer {
 	public static Value v(def value) {
 		return new Value("{\"value\":"+value+"}");
 	}
-
+	
 	public static Translation j(def map) {
 		return new Translation(jsonText: JSONUtils.getJSONFromMap(map));
 	}

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -123,6 +123,7 @@ dsr.target.label=DSR Target
 dsr.target.format.label=Format
 dsr.target.program.label=Program
 dsr.target.category.label=Category
+dsr.target.calculationelement.label=Calculation or Data Element
 dsr.target.dataelement.label=Data Element
 dsr.category.label=DSR Category
 fct.target.label=FCT Target

--- a/grails-app/i18n/messages_fr.properties
+++ b/grails-app/i18n/messages_fr.properties
@@ -123,6 +123,7 @@ dsr.target.label=Indicateur DSR
 dsr.target.format.label=Format
 dsr.target.program.label=Programme
 dsr.target.category.label=Catégorie
+dsr.target.calculationelement.label=Calcul aggrégé ou Elément de donnée
 dsr.target.dataelement.label=Elément de donnée
 dsr.category.label=Catégorie DSR
 fct.target.label=Indicateur FCT

--- a/grails-app/services/org/chai/kevin/dsr/DsrService.java
+++ b/grails-app/services/org/chai/kevin/dsr/DsrService.java
@@ -66,7 +66,7 @@ public class DsrService {
 		Collections.sort(targets);
 				
 		for (DsrTarget target : targets) {
-			Calculation calculation = dataService.getData(target.getCalculationElement().getId(), Calculation.class);
+			Calculation calculation = dataService.getData(target.getData().getId(), Calculation.class);
 			if(calculation != null){				
 				for(Location treeLocation : treeLocations){					
 					if(!valueMap.containsKey(treeLocation))
@@ -80,7 +80,7 @@ public class DsrService {
 				}	
 			}
 			else{
-				DataElement dataElement = dataService.getData(target.getCalculationElement().getId(), DataElement.class);
+				DataElement dataElement = dataService.getData(target.getData().getId(), DataElement.class);
 				if(dataElement != null){
 					for(DataLocation dataLocation : dataLocations){										
 						if(!valueMap.containsKey(dataLocation))

--- a/grails-app/services/org/chai/kevin/dsr/DsrTable.java
+++ b/grails-app/services/org/chai/kevin/dsr/DsrTable.java
@@ -3,6 +3,7 @@ package org.chai.kevin.dsr;
 import java.util.List;
 import java.util.Map;
 
+import org.chai.kevin.location.CalculationLocation;
 import org.chai.kevin.location.DataLocation;
 import org.chai.kevin.reports.ReportTable;
 import org.chai.kevin.value.Value;
@@ -35,12 +36,12 @@ import org.chai.kevin.value.Value;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-public class DsrTable extends ReportTable<DsrTarget, DataLocation> {
+public class DsrTable extends ReportTable<DsrTarget, CalculationLocation> {
 	
 	private List<DsrTarget> targets;
 	private List<DsrTargetCategory> targetCategories;		
 	
-	public DsrTable(Map<DataLocation, Map<DsrTarget, Value>> valueMap, 
+	public DsrTable(Map<CalculationLocation, Map<DsrTarget, Value>> valueMap, 
 			List<DsrTarget> targets, List<DsrTargetCategory> targetCategories) {
 		super(valueMap);
 		this.targets = targets;

--- a/grails-app/services/org/chai/kevin/fct/FctTable.java
+++ b/grails-app/services/org/chai/kevin/fct/FctTable.java
@@ -76,10 +76,6 @@ public class FctTable extends ReportTable<FctTargetOption, CalculationLocation> 
 		return targets;
 	}
 	
-	public Set<CalculationLocation> getLocations(){
-		return valueMap.keySet();
-	}	
-	
 	public boolean hasData(){
 		return (super.hasData());
 	}

--- a/grails-app/services/org/chai/kevin/reports/ReportTable.java
+++ b/grails-app/services/org/chai/kevin/reports/ReportTable.java
@@ -1,6 +1,7 @@
 package org.chai.kevin.reports;
 
 import java.util.Map;
+import java.util.Set;
 
 import org.chai.kevin.location.CalculationLocation;
 import org.chai.kevin.value.Value;
@@ -11,6 +12,10 @@ public abstract class ReportTable<T, S extends CalculationLocation> {
 	
 	public ReportTable(Map<S, Map<T, Value>> valueMap) {
 		this.valueMap = valueMap;
+	}
+	
+	public Set<S> getLocations(){
+		return valueMap.keySet();
 	}
 	
 	public boolean hasData(){

--- a/grails-app/views/dsr/_reportProgramTableTree.gsp
+++ b/grails-app/views/dsr/_reportProgramTableTree.gsp
@@ -7,7 +7,7 @@
 			<g:each in="${dsrTable.targets}" var="target">
 				<td>
 					<g:if test="${dsrTable.getReportValue(location, target) != null}">
-						<g:reportValue value="${dsrTable.getReportValue(location, target)}" type="${target.dataElement.type}" format="${target.format}"/>
+						<g:reportValue value="${dsrTable.getReportValue(location, target)}" type="${target.calculationElement.type}" format="${target.format}"/>
 					</g:if>
 					<g:else>
 						<div class="report-value-na"><g:message code="report.value.na"/></div>
@@ -24,7 +24,11 @@
 				<span style="margin-left: ${level*20}px;"><g:i18n field="${location.names}"/></span>
 			</td>
 			<g:each in="${dsrTable.targets}" var="target">
-				<td></td>
+				<td>
+					<g:if test="${dsrTable.getReportValue(location, target) != null}">
+						<g:reportValue value="${dsrTable.getReportValue(location, target)}" type="${target.calculationElement.type}" format="${target.format}"/>
+					</g:if>					
+				</td>
 			</g:each>
 		</tr>
 		<tr class="sub-tree js_foldable-container hidden"

--- a/grails-app/views/dsr/_reportProgramTableTree.gsp
+++ b/grails-app/views/dsr/_reportProgramTableTree.gsp
@@ -7,7 +7,7 @@
 			<g:each in="${dsrTable.targets}" var="target">
 				<td>
 					<g:if test="${dsrTable.getReportValue(location, target) != null}">
-						<g:reportValue value="${dsrTable.getReportValue(location, target)}" type="${target.calculationElement.type}" format="${target.format}"/>
+						<g:reportValue value="${dsrTable.getReportValue(location, target)}" type="${target.data.type}" format="${target.format}"/>
 					</g:if>
 					<g:else>
 						<div class="report-value-na"><g:message code="report.value.na"/></div>
@@ -26,7 +26,7 @@
 			<g:each in="${dsrTable.targets}" var="target">
 				<td>
 					<g:if test="${dsrTable.getReportValue(location, target) != null}">
-						<g:reportValue value="${dsrTable.getReportValue(location, target)}" type="${target.calculationElement.type}" format="${target.format}"/>
+						<g:reportValue value="${dsrTable.getReportValue(location, target)}" type="${target.data.type}" format="${target.format}"/>
 					</g:if>					
 				</td>
 			</g:each>

--- a/grails-app/views/entity/dsr/_createTarget.gsp
+++ b/grails-app/views/entity/dsr/_createTarget.gsp
@@ -17,10 +17,10 @@
 		<g:selectFromList name="category.id" label="${message(code:'dsr.target.category.label')}" bean="${target}" field="category" optionKey="id" multiple="false"
 			from="${categories}" value="${target.category?.id}" values="${categories.collect{i18n(field:it.names)}}" />
 	
-		<g:selectFromList name="dataElement.id" label="${message(code:'dsr.target.dataelement.label')}" bean="${target}" field="dataElement" optionKey="id" multiple="false"
-			ajaxLink="${createLink(controller:'data', action:'getAjaxData', params:[class:'DataElement'])}"
-			from="${dataElements}" value="${target.dataElement?.id}" values="${dataElements.collect{i18n(field:it.names)+' ['+it.code+'] ['+it.class.simpleName+']'}}" />
-	
+		<g:selectFromList name="calculationElement.id" label="${message(code:'dsr.target.calculationelement.label')}" bean="${target}" field="calculationElement" optionKey="id" multiple="false"
+			ajaxLink="${createLink(controller:'data', action:'getAjaxData', params:[class:'Data'])}"
+			from="${calculationElements}" value="${target.calculationElement?.id}" values="${calculationElements.collect{i18n(field:it.names)+' ['+it.code+'] ['+it.class.simpleName+']'}}" />
+
 		<g:input name="order" label="${message(code:'entity.order.label')}" bean="${target}" field="order"/>
 		
 		<g:if test="${target != null}">
@@ -33,4 +33,3 @@
     </g:form>
 	<div class="clear"></div>
 </div>
-

--- a/grails-app/views/entity/dsr/_createTarget.gsp
+++ b/grails-app/views/entity/dsr/_createTarget.gsp
@@ -17,9 +17,9 @@
 		<g:selectFromList name="category.id" label="${message(code:'dsr.target.category.label')}" bean="${target}" field="category" optionKey="id" multiple="false"
 			from="${categories}" value="${target.category?.id}" values="${categories.collect{i18n(field:it.names)}}" />
 	
-		<g:selectFromList name="calculationElement.id" label="${message(code:'dsr.target.calculationelement.label')}" bean="${target}" field="calculationElement" optionKey="id" multiple="false"
+		<g:selectFromList name="data.id" label="${message(code:'dsr.target.calculationelement.label')}" bean="${target}" field="data" optionKey="id" multiple="false"
 			ajaxLink="${createLink(controller:'data', action:'getAjaxData', params:[class:'Data'])}"
-			from="${calculationElements}" value="${target.calculationElement?.id}" values="${calculationElements.collect{i18n(field:it.names)+' ['+it.code+'] ['+it.class.simpleName+']'}}" />
+			from="${data}" value="${target.data?.id}" values="${data.collect{i18n(field:it.names)+' ['+it.code+'] ['+it.class.simpleName+']'}}" />
 
 		<g:input name="order" label="${message(code:'entity.order.label')}" bean="${target}" field="order"/>
 		

--- a/grails-app/views/entity/dsr/_targetList.gsp
+++ b/grails-app/views/entity/dsr/_targetList.gsp
@@ -33,7 +33,7 @@
 				<td>
 					<g:i18n field="${target.program.names}"/>
 				</td>
-				<td>${target.calculationElement.code}</td>
+				<td>${target.data.code}</td>
 				<td>
 					<g:i18n field="${target.category?.names}"/>
 				</td>

--- a/grails-app/views/entity/dsr/_targetList.gsp
+++ b/grails-app/views/entity/dsr/_targetList.gsp
@@ -5,7 +5,7 @@
 			<th><g:message code="entity.code.label"/></th>
 			<th><g:message code="entity.name.label"/></th>
 			<th><g:message code="dsr.target.program.label"/></th>
-			<th><g:message code="dsr.target.dataelement.label"/></th>
+			<th><g:message code="dsr.target.calculationelement.label"/></th>
 			<th><g:message code="dsr.target.category.label"/></th>
 			<th><g:message code="entity.order.label"/></th>
 		</tr>
@@ -33,7 +33,7 @@
 				<td>
 					<g:i18n field="${target.program.names}"/>
 				</td>
-				<td>${target.dataElement.code}</td>
+				<td>${target.calculationElement.code}</td>
 				<td>
 					<g:i18n field="${target.category?.names}"/>
 				</td>

--- a/src/java/org/chai/kevin/dsr/DsrTarget.java
+++ b/src/java/org/chai/kevin/dsr/DsrTarget.java
@@ -44,6 +44,7 @@ import javax.persistence.UniqueConstraint;
 
 import org.chai.kevin.Exportable;
 import org.chai.kevin.Importable;
+import org.chai.kevin.data.Data;
 import org.chai.kevin.data.DataElement;
 import org.chai.kevin.reports.AbstractReportTarget;
 import org.chai.kevin.util.Utils;
@@ -57,7 +58,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 public class DsrTarget extends AbstractReportTarget implements Exportable, Importable {
 	
 	private Long id;
-	private DataElement<StoredValue> dataElement;
+	private Data<StoredValue> calculationElement; //this can be either a calculation or a data element
 	private DsrTargetCategory category;
 	private String format;
 	
@@ -68,16 +69,16 @@ public class DsrTarget extends AbstractReportTarget implements Exportable, Impor
 	}	
 	public void setId(Long id) {
 		this.id = id;
-	}
+	}	
 	
-	@ManyToOne(targetEntity=DataElement.class, optional=false)
-	public DataElement<StoredValue> getDataElement() {
-		return dataElement;
+	@ManyToOne(targetEntity=Data.class, optional=false)
+	public Data<StoredValue> getCalculationElement() {
+		return calculationElement;
 	}
 
-	public void setDataElement(DataElement<StoredValue> dataElement) {
-		this.dataElement = dataElement;
-	}
+	public void setCalculationElement(Data<StoredValue> calculationElement) {
+		this.calculationElement = calculationElement;
+	}	
 
 	@ManyToOne(targetEntity=DsrTargetCategory.class)
 	public DsrTargetCategory getCategory() {

--- a/src/java/org/chai/kevin/dsr/DsrTarget.java
+++ b/src/java/org/chai/kevin/dsr/DsrTarget.java
@@ -58,7 +58,7 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 public class DsrTarget extends AbstractReportTarget implements Exportable, Importable {
 	
 	private Long id;
-	private Data<StoredValue> calculationElement; //this can be either a calculation or a data element
+	private Data<StoredValue> data; //this can be either a calculation or a data element
 	private DsrTargetCategory category;
 	private String format;
 	
@@ -72,12 +72,12 @@ public class DsrTarget extends AbstractReportTarget implements Exportable, Impor
 	}	
 	
 	@ManyToOne(targetEntity=Data.class, optional=false)
-	public Data<StoredValue> getCalculationElement() {
-		return calculationElement;
+	public Data<StoredValue> getData() {
+		return data;
 	}
 
-	public void setCalculationElement(Data<StoredValue> calculationElement) {
-		this.calculationElement = calculationElement;
+	public void setData(Data<StoredValue> data) {
+		this.data = data;
 	}	
 
 	@ManyToOne(targetEntity=DsrTargetCategory.class)

--- a/src/java/org/chai/kevin/dsr/DsrTargetConstraints.groovy
+++ b/src/java/org/chai/kevin/dsr/DsrTargetConstraints.groovy
@@ -35,7 +35,7 @@ package org.chai.kevin.dsr;
 constraints = {
 	code (nullable: false, blank: false, unique: true)
 //	dataElement (nullable: false)
-	calculationElement (nullable: false)
+	data (nullable: false)
 //	category(nullable: false)
 	program (nullable: false)
 }

--- a/src/java/org/chai/kevin/dsr/DsrTargetConstraints.groovy
+++ b/src/java/org/chai/kevin/dsr/DsrTargetConstraints.groovy
@@ -34,7 +34,8 @@ package org.chai.kevin.dsr;
 
 constraints = {
 	code (nullable: false, blank: false, unique: true)
-	dataElement (nullable: false)
+//	dataElement (nullable: false)
+	calculationElement (nullable: false)
 //	category(nullable: false)
 	program (nullable: false)
 }

--- a/src/java/org/chai/kevin/fct/FctTarget.java
+++ b/src/java/org/chai/kevin/fct/FctTarget.java
@@ -56,6 +56,8 @@ public class FctTarget extends AbstractReportTarget implements Exportable {
 	
 	private Long id;
 	private List<FctTargetOption> targetOptions = new ArrayList<FctTargetOption>();
+	
+	//TODO get rid of this ?
 	private String typeCodeString; //comma-separated list of location type ids
 	
 	@Id
@@ -76,11 +78,13 @@ public class FctTarget extends AbstractReportTarget implements Exportable {
 		this.targetOptions = targetOptions;
 	}
 
+	//TODO get rid of this ?
     @Lob
 	public String getTypeCodeString() {
 		return typeCodeString;
     }
 
+  //TODO get rid of this ?
 	public void setTypeCodeString(String typeCodeString) {
 		this.typeCodeString = typeCodeString;
 	}

--- a/test/integration/org/chai/kevin/dsr/DsrIntegrationTests.groovy
+++ b/test/integration/org/chai/kevin/dsr/DsrIntegrationTests.groovy
@@ -8,12 +8,12 @@ import org.chai.kevin.util.Utils;
 
 abstract class DsrIntegrationTests extends IntegrationTests {
 	
-	static def newDsrTarget(def code, def order, def calculationElement, def format, def program, def category) {
+	static def newDsrTarget(def code, def order, def data, def format, def program, def category) {
 		def target = new DsrTarget(names: [:],
 			code: code,
 			order: order,
 			format: format,
-			calculationElement: calculationElement,
+			data: data,
 			program: program,
 			category: category
 		).save(failOnError: true)
@@ -25,16 +25,16 @@ abstract class DsrIntegrationTests extends IntegrationTests {
 		return target
 	}
 	
-	static def newDsrTarget(def code, def calculationElement, def program) {
-		return newDsrTarget(code, null, calculationElement, null, program, null)
+	static def newDsrTarget(def code, def data, def program) {
+		return newDsrTarget(code, null, data, null, program, null)
 	}
 	
-	static def newDsrTarget(def code, def order, def calculationElement, def program) {
-		return newDsrTarget(code, order, calculationElement, null, program, null)
+	static def newDsrTarget(def code, def order, def data, def program) {
+		return newDsrTarget(code, order, data, null, program, null)
 	}
 	
-	static def newDsrTarget(def code, def order, def calculationElement, def program, def category) {
-		return newDsrTarget(code, order, calculationElement, null, program, category)
+	static def newDsrTarget(def code, def order, def data, def program, def category) {
+		return newDsrTarget(code, order, data, null, program, category)
 	}
 	
 	static def newDsrTargetCategory(def code, def order) {

--- a/test/integration/org/chai/kevin/dsr/DsrIntegrationTests.groovy
+++ b/test/integration/org/chai/kevin/dsr/DsrIntegrationTests.groovy
@@ -8,12 +8,12 @@ import org.chai.kevin.util.Utils;
 
 abstract class DsrIntegrationTests extends IntegrationTests {
 	
-	static def newDsrTarget(def code, def order, def dataElement, def format, def program, def category) {
+	static def newDsrTarget(def code, def order, def calculationElement, def format, def program, def category) {
 		def target = new DsrTarget(names: [:],
 			code: code,
 			order: order,
 			format: format,
-			dataElement: dataElement,
+			calculationElement: calculationElement,
 			program: program,
 			category: category
 		).save(failOnError: true)
@@ -25,16 +25,16 @@ abstract class DsrIntegrationTests extends IntegrationTests {
 		return target
 	}
 	
-	static def newDsrTarget(def code, def dataElement, def program) {
-		return newDsrTarget(code, null, dataElement, null, program, null)
+	static def newDsrTarget(def code, def calculationElement, def program) {
+		return newDsrTarget(code, null, calculationElement, null, program, null)
 	}
 	
-	static def newDsrTarget(def code, def order, def dataElement, def program) {
-		return newDsrTarget(code, order, dataElement, null, program, null)
+	static def newDsrTarget(def code, def order, def calculationElement, def program) {
+		return newDsrTarget(code, order, calculationElement, null, program, null)
 	}
 	
-	static def newDsrTarget(def code, def order, def dataElement, def program, def category) {
-		return newDsrTarget(code, order, dataElement, null, program, category)
+	static def newDsrTarget(def code, def order, def calculationElement, def program, def category) {
+		return newDsrTarget(code, order, calculationElement, null, program, category)
 	}
 	
 	static def newDsrTargetCategory(def code, def order) {

--- a/test/integration/org/chai/kevin/dsr/DsrServiceSpec.groovy
+++ b/test/integration/org/chai/kevin/dsr/DsrServiceSpec.groovy
@@ -9,143 +9,314 @@ import org.chai.kevin.value.Value;
 
 class DsrServiceSpec extends DsrIntegrationTests {
 
-	def dsrService	
-	
-	def "normal dsr service"() {
+	def dsrService
+
+	def "get dsr"() {
 		setup:
 		setupLocationTree()
 		def period = newPeriod()
 		def program = newReportProgram(CODE(1))
-		def dataElement = newRawDataElement(CODE(2), Type.TYPE_NUMBER())
-		def target = newDsrTarget(CODE(3), 1, dataElement, program)		
-		
-		when:
 		def location = Location.findByCode(BURERA)
-		def types = new HashSet([DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP), DataLocationType.findByCode(HEALTH_CENTER_GROUP)])
+		def dataElement = newRawDataElement(CODE(2), Type.TYPE_NUMBER())
+		def target = newDsrTarget(CODE(3), 1, dataElement, program)
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
+
+		when:
 		def dsrTable = dsrService.getDsrTable(location, program, period, types, null)
-		
+
 		then:
 		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target) == null
-		
+
 		when:
 		newRawDataElementValue(dataElement, period, DataLocation.findByCode(BUTARO), Value.VALUE_NUMBER(10d))
 		dsrTable = dsrService.getDsrTable(location, program, period, types, null)
-		
-		then:
-		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 10d	
 
+		then:
+		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 10d
 	}
-	
+
+	def "get dsr with average calculation element"(){
+		setup:
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(CODE(1))
+		def burera = Location.findByCode(BURERA)
+		def average = newAverage("1", CODE(2))
+		def target = newDsrTarget(CODE(3), 1, average, program)
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
+		refreshCalculation()
+
+		when:
+		def dsrTable = dsrService.getDsrTable(burera, program, period, types, null)
+
+		then:
+		dsrTable != null
+		dsrTable.hasData() == true
+		dsrTable.locations.findAll{ it -> it instanceof DataLocation }.size() == 2
+		dsrTable.locations.findAll{ it -> it instanceof Location }.size() == 1
+		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 1
+		dsrTable.getReportValue(DataLocation.findByCode(KIVUYE), target).getNumberValue() == 1
+		dsrTable.getReportValue(Location.findByCode(BURERA), target).getNumberValue() == 1
+	}
+
+
+	def "get dsr with sum calculation element"(){
+		setup:
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(CODE(1))
+		def burera = Location.findByCode(BURERA)
+		def sum = newSum("1", CODE(2))
+		def target = newDsrTarget(CODE(3), 1, sum, program)
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
+		refreshCalculation()
+
+		when:
+		def dsrTable = dsrService.getDsrTable(burera, program, period, types, null)
+
+		then:
+		dsrTable != null
+		dsrTable.hasData() == true
+		dsrTable.locations.findAll{ it -> it instanceof DataLocation }.size() == 2
+		dsrTable.locations.findAll{ it -> it instanceof Location }.size() == 1
+		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 1
+		dsrTable.getReportValue(DataLocation.findByCode(KIVUYE), target).getNumberValue() == 1
+		dsrTable.getReportValue(Location.findByCode(BURERA), target).getNumberValue() == 2		
+	}
+
+
+	def "get dsr with raw data element calculation element"(){
+		setup:
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(CODE(1))
+		def location = Location.findByCode(BURERA)
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
+		def rawDataElement = newRawDataElement(CODE(2), Type.TYPE_NUMBER())
+		def target = newDsrTarget(CODE(3), 1, rawDataElement, program)
+		newRawDataElementValue(rawDataElement, period, DataLocation.findByCode(BUTARO), Value.VALUE_NUMBER(10d))
+
+		when:
+		def dsrTable = dsrService.getDsrTable(location, program, period, types, null)
+
+		then:
+		dsrTable != null
+		dsrTable.hasData() == true
+		dsrTable.locations.findAll{ it -> it instanceof DataLocation }.size() == 2
+		dsrTable.locations.findAll{ it -> it instanceof Location }.size() == 0
+		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 10d
+		dsrTable.getReportValue(DataLocation.findByCode(KIVUYE), target) == null
+
+		when:
+		newRawDataElementValue(rawDataElement, period, DataLocation.findByCode(KIVUYE), Value.VALUE_NUMBER(10d))
+		dsrTable = dsrService.getDsrTable(location, program, period, types, null)
+
+		then:
+		dsrTable != null
+		dsrTable.hasData() == true
+		dsrTable.locations.findAll{ it -> it instanceof DataLocation }.size() == 2
+		dsrTable.locations.findAll{ it -> it instanceof Location }.size() == 0
+		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 10d
+		dsrTable.getReportValue(DataLocation.findByCode(KIVUYE), target).getNumberValue() == 10d
+	}
+
+
+	def "get dsr with normalized data element calculation element"(){
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(CODE(1))
+		def location = Location.findByCode(BURERA)
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
+		def normalizedDataElement = newNormalizedDataElement(CODE(1), Type.TYPE_NUMBER(), e([(period.id+''):[(DISTRICT_HOSPITAL_GROUP):"10",(HEALTH_CENTER_GROUP):"10"]]))
+		def target = newDsrTarget(CODE(3), 1, normalizedDataElement, program)
+		refreshNormalizedDataElement()
+
+		when:
+		def dsrTable = dsrService.getDsrTable(location, program, period, types, null)
+
+		then:
+		dsrTable != null
+		dsrTable.hasData() == true
+		dsrTable.locations.findAll{ it -> it instanceof DataLocation }.size() == 2
+		dsrTable.locations.findAll{ it -> it instanceof Location }.size() == 0
+		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 10d
+		dsrTable.getReportValue(DataLocation.findByCode(KIVUYE), target).getNumberValue() == 10d
+	}
+
+
+	def "get dsr with normalized data element calculation element and no expression"(){
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(CODE(1))
+		def location = Location.findByCode(BURERA)
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
+		def normalizedDataElement = newNormalizedDataElement(CODE(2), Type.TYPE_NUMBER(), e([(period.id+''):[(DISTRICT_HOSPITAL_GROUP):"10"]]))
+		def target = newDsrTarget(CODE(3), 1, normalizedDataElement, program)
+		refreshNormalizedDataElement()
+
+		when:
+		def dsrTable = dsrService.getDsrTable(location, program, period, types, null)
+
+		then:
+		dsrTable != null
+		dsrTable.hasData() == true
+		dsrTable.locations.findAll{ it -> it instanceof DataLocation }.size() == 2
+		dsrTable.locations.findAll{ it -> it instanceof Location }.size() == 0
+		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 10d
+		dsrTable.getReportValue(DataLocation.findByCode(KIVUYE), target) == v(null)
+	}
+
+	def "get dsr with types"() {
+		setup:
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(CODE(2))
+		def location = Location.findByCode(BURERA)
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
+		def normalizedDataElement = newNormalizedDataElement(CODE(1), Type.TYPE_NUMBER(), e([(period.id+''):[(DISTRICT_HOSPITAL_GROUP):"10",(HEALTH_CENTER_GROUP):"10"]]))
+		def target = newDsrTarget(CODE(3), 1, normalizedDataElement, program)
+		refreshNormalizedDataElement()
+
+		when:
+		def dsrTable = dsrService.getDsrTable(location, program, period, types, null)
+
+		then:
+		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 10d
+		dsrTable.getReportValue(DataLocation.findByCode(KIVUYE), target).getNumberValue() == 10d
+	}
+
+
+	def "get dsr with category"() {
+		setup:
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(ROOT)
+		def location = Location.findByCode(BURERA)
+		def category1 = newDsrTargetCategory(CODE(2), 1)
+		def dataElement1 = newRawDataElement(CODE(3), Type.TYPE_NUMBER())
+		def target1 = newDsrTarget(CODE(4), 1, dataElement1, program, category1)
+		def category2 = newDsrTargetCategory(CODE(5), 2)
+		def dataElement2 = newRawDataElement(CODE(6), Type.TYPE_NUMBER())
+		def target2 = newDsrTarget(CODE(7), 2, dataElement2, program, category2)
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
+		refresh()
+
+		when:
+		def dsrTable = dsrService.getDsrTable(location, program, period, types, category1)
+
+		then:
+		dsrTable.targetCategories.size == 2
+		dsrTable.targetCategories.equals([category1, category2])
+		dsrTable.targets.size == 1
+		dsrTable.targets.equals([target1])
+		dsrTable.targets.get(0).category.equals(category1)
+	}
+
+
 	def "get dsr with sorted targets"() {
 		setup:
 		setupLocationTree()
 		def period = newPeriod()
 		def program = newReportProgram(ROOT)
+		def location = Location.findByCode(BURERA)
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
 		def dataElement1 = newRawDataElement(CODE(2), Type.TYPE_NUMBER())
 		def target1 = newDsrTarget(CODE(3), 1, dataElement1, program)
 		def dataElement2 = newRawDataElement(CODE(4), Type.TYPE_NUMBER())
 		def target2 = newDsrTarget(CODE(5), 2, dataElement2, program)
 		refresh()
-		
+
 		when:
-		def location = Location.findByCode(BURERA)
-		def types = new HashSet([DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP), DataLocationType.findByCode(HEALTH_CENTER_GROUP)])
 		def dsrTable = dsrService.getDsrTable(location, program, period, types, null)
-		
+
 		then:
 		dsrTable.targets[0].equals(DsrTarget.findByCode(CODE(3)))
 		dsrTable.targets[1].equals(DsrTarget.findByCode(CODE(5)))
-		
+
 		when:
 		DsrTarget.findByCode(CODE(3)).order = 2
 		DsrTarget.findByCode(CODE(5)).order = 1
 		dsrTable = dsrService.getDsrTable(location, program, period, types, null)
-		
+
 		then:
 		dsrTable.targets[0].equals(DsrTarget.findByCode(CODE(5)))
 		dsrTable.targets[1].equals(DsrTarget.findByCode(CODE(3)))
 	}
-	
+
+
 	def "get dsr with sorted target categories"() {
 		setup:
 		setupLocationTree()
 		def period = newPeriod()
 		def program = newReportProgram(ROOT)
-		def cat1 = newDsrTargetCategory(CODE(2), 1)
-		def dataElement1 = newRawDataElement(CODE(3), Type.TYPE_NUMBER())
-		def target1 = newDsrTarget(CODE(4), 1, dataElement1, program, cat1)
-		def cat2 = newDsrTargetCategory(CODE(5), 2)
-		def dataElement2 = newRawDataElement(CODE(6), Type.TYPE_NUMBER())
-		def target2 = newDsrTarget(CODE(7), 2, dataElement2, program, cat2)
-		refresh()
-		
-		when:
 		def location = Location.findByCode(BURERA)
-		def types = new HashSet([DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP), DataLocationType.findByCode(HEALTH_CENTER_GROUP)])
+		def types = new HashSet([
+			DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP),
+			DataLocationType.findByCode(HEALTH_CENTER_GROUP)
+		])
+		def category1 = newDsrTargetCategory(CODE(2), 1)
+		def dataElement1 = newRawDataElement(CODE(3), Type.TYPE_NUMBER())
+		def target1 = newDsrTarget(CODE(4), 1, dataElement1, program, category1)
+		def category2 = newDsrTargetCategory(CODE(5), 2)
+		def dataElement2 = newRawDataElement(CODE(6), Type.TYPE_NUMBER())
+		def target2 = newDsrTarget(CODE(7), 2, dataElement2, program, category2)
+		refresh()
+
+		when:
 		def dsrTable = dsrService.getDsrTable(location, program, period, types, null)
-		
+
 		then:
-		dsrTable.targetCategories[0].equals(DsrTargetCategory.findByCode(CODE(2)))
-		dsrTable.targetCategories[1].equals(DsrTargetCategory.findByCode(CODE(5)))
-		
+		dsrTable.targetCategories[0].equals(category1)
+		dsrTable.targetCategories[1].equals(category2)
+
 		when:
 		DsrTargetCategory.findByCode(CODE(2)).order = 2
 		DsrTargetCategory.findByCode(CODE(5)).order = 1
 		dsrTable = dsrService.getDsrTable(location, program, period, types, null)
-		
+
 		then:
-		dsrTable.targetCategories[0].equals(DsrTargetCategory.findByCode(CODE(5)))
-		dsrTable.targetCategories[1].equals(DsrTargetCategory.findByCode(CODE(2)))
+		dsrTable.targetCategories[0].equals(category2)
+		dsrTable.targetCategories[1].equals(category1)
 	}
-	
-	def "get dsr with types"() {
-		setup:
-		setupLocationTree()
-		def period = newPeriod()
-		def normalizedDataElement = newNormalizedDataElement(CODE(1), Type.TYPE_NUMBER(), e([(period.id+''):[(DISTRICT_HOSPITAL_GROUP):"10",(HEALTH_CENTER_GROUP):"10"]]))
-		def program = newReportProgram(CODE(2))
-		def target = newDsrTarget(CODE(3), 1, normalizedDataElement, program)	
-		refreshNormalizedDataElement()
-		def location = Location.findByCode(BURERA)
-		def types = new HashSet([DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP), DataLocationType.findByCode(HEALTH_CENTER_GROUP)])
-		
-		when:
-		def dsrTable = dsrService.getDsrTable(location, program, period, types, null)
-		
-		then:
-		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 10d	
-		dsrTable.getReportValue(DataLocation.findByCode(KIVUYE), target).getNumberValue() == 10d
-		
-	}
-	
-	def "get dsr with normalized data element and no expression"() {
-		setup:
-		setupLocationTree()
-		def period = newPeriod()
-		def normalizedDataElement = newNormalizedDataElement(CODE(1), Type.TYPE_NUMBER(), e([(period.id+''):[(DISTRICT_HOSPITAL_GROUP):"10"]]))
-		def program = newReportProgram(CODE(2))
-		def target = newDsrTarget(CODE(3), 1, normalizedDataElement, program)
-		refreshNormalizedDataElement()
-		def location = Location.findByCode(BURERA)
-		def types = new HashSet([DataLocationType.findByCode(DISTRICT_HOSPITAL_GROUP), DataLocationType.findByCode(HEALTH_CENTER_GROUP)])
-		
-		when:
-		def dsrTable = dsrService.getDsrTable(location, program, period, types, null)		
-		
-		then:
-		dsrTable.getReportValue(DataLocation.findByCode(BUTARO), target).getNumberValue() == 10d
-		dsrTable.getReportValue(DataLocation.findByCode(KIVUYE), target).isNull()
-		
-	}
-	
+
+
 	def "get dsr skip levels"(){
 		setup:
 		setupLocationTree()
-		
+
 		when:
 		def dsrSkipLevels = dsrService.getSkipLocationLevels()
-		
+
 		then:
-		dsrSkipLevels.equals(s([LocationLevel.findByCode(SECTOR)])) 
+		dsrSkipLevels.equals(s([
+			LocationLevel.findByCode(SECTOR)
+		]))
 	}
 }

--- a/test/integration/org/chai/kevin/dsr/DsrTargetControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/dsr/DsrTargetControllerSpec.groovy
@@ -38,24 +38,81 @@ class DsrTargetControllerSpec extends DsrIntegrationTests {
 	def dataService
 	def dsrService	
 	
-	def "save target saves target"() {
+	def "create target with average calculation element"(){
 		setup:
 		setupLocationTree()
 		def program = newReportProgram(CODE(1))
-		def dataElement = newRawDataElement(CODE(3), Type.TYPE_NUMBER())
+		def average = newAverage("1", CODE(2))
 		dsrTargetController = new DsrTargetController()
 		dsrTargetController.dataService = dataService
 		
 		when:
-		dsrTargetController.params.code = CODE(2)
-		dsrTargetController.params['dataElement.id'] = dataElement.id+""
+		dsrTargetController.params.code = CODE(4)
+		dsrTargetController.params['calculationElement.id'] = average.id+""
 		dsrTargetController.params['program.id'] = program.id+""
-		dsrTargetController.params.typeCodes = [DISTRICT_HOSPITAL_GROUP]
 		dsrTargetController.saveWithoutTokenCheck()
 		
 		then:
 		DsrTarget.count() == 1
-		DsrTarget.list()[0].dataElement.equals(dataElement)
+		DsrTarget.list()[0].calculationElement.equals(average)				
+	}
+	
+	def "create target with sum calculation element"(){
+		setup:
+		setupLocationTree()
+		def program = newReportProgram(CODE(1))
+		def sum = newSum("1", CODE(2))
+		dsrTargetController = new DsrTargetController()
+		dsrTargetController.dataService = dataService
+		
+		when:
+		dsrTargetController.params.code = CODE(5)
+		dsrTargetController.params['calculationElement.id'] = sum.id+""
+		dsrTargetController.params['program.id'] = program.id+""
+		dsrTargetController.saveWithoutTokenCheck()
+		
+		then:
+		DsrTarget.count() == 1
+		DsrTarget.list()[0].calculationElement.equals(sum)
+	}
+	
+	def "create target with raw data element calculation element"() {
+		setup:
+		setupLocationTree()
+		def program = newReportProgram(CODE(1))
+		def rawDataElement = newRawDataElement(CODE(2), Type.TYPE_NUMBER())
+		dsrTargetController = new DsrTargetController()
+		dsrTargetController.dataService = dataService
+		
+		when:
+		dsrTargetController.params.code = CODE(3)
+		dsrTargetController.params['calculationElement.id'] = rawDataElement.id+""
+		dsrTargetController.params['program.id'] = program.id+""
+		dsrTargetController.saveWithoutTokenCheck()
+		
+		then:
+		DsrTarget.count() == 1
+		DsrTarget.list()[0].calculationElement.equals(rawDataElement)				
+	}
+	
+	def "create target with normalized data element calculation element"() {
+		setup:
+		setupLocationTree()
+		def period = newPeriod()
+		def program = newReportProgram(CODE(1))
+		def normalizedDataElement = newNormalizedDataElement(CODE(4), Type.TYPE_NUMBER(), e([(period.id+''):[(DISTRICT_HOSPITAL_GROUP):"10",(HEALTH_CENTER_GROUP):"10"]]))
+		dsrTargetController = new DsrTargetController()
+		dsrTargetController.dataService = dataService
+		
+		when:
+		dsrTargetController.params.code = CODE(5)
+		dsrTargetController.params['calculationElement.id'] = normalizedDataElement.id+""
+		dsrTargetController.params['program.id'] = program.id+""
+		dsrTargetController.saveWithoutTokenCheck()
+		
+		then:
+		DsrTarget.count() == 1
+		DsrTarget.list()[0].calculationElement.equals(normalizedDataElement)
 	}
 	
 	def "delete target" () {
@@ -73,6 +130,6 @@ class DsrTargetControllerSpec extends DsrIntegrationTests {
 		
 		then:
 		DsrTarget.count() == 0
-	}
+	}	
 	
 }

--- a/test/integration/org/chai/kevin/dsr/DsrTargetControllerSpec.groovy
+++ b/test/integration/org/chai/kevin/dsr/DsrTargetControllerSpec.groovy
@@ -48,13 +48,13 @@ class DsrTargetControllerSpec extends DsrIntegrationTests {
 		
 		when:
 		dsrTargetController.params.code = CODE(4)
-		dsrTargetController.params['calculationElement.id'] = average.id+""
+		dsrTargetController.params['data.id'] = average.id+""
 		dsrTargetController.params['program.id'] = program.id+""
 		dsrTargetController.saveWithoutTokenCheck()
 		
 		then:
 		DsrTarget.count() == 1
-		DsrTarget.list()[0].calculationElement.equals(average)				
+		DsrTarget.list()[0].data.equals(average)				
 	}
 	
 	def "create target with sum calculation element"(){
@@ -67,13 +67,13 @@ class DsrTargetControllerSpec extends DsrIntegrationTests {
 		
 		when:
 		dsrTargetController.params.code = CODE(5)
-		dsrTargetController.params['calculationElement.id'] = sum.id+""
+		dsrTargetController.params['data.id'] = sum.id+""
 		dsrTargetController.params['program.id'] = program.id+""
 		dsrTargetController.saveWithoutTokenCheck()
 		
 		then:
 		DsrTarget.count() == 1
-		DsrTarget.list()[0].calculationElement.equals(sum)
+		DsrTarget.list()[0].data.equals(sum)
 	}
 	
 	def "create target with raw data element calculation element"() {
@@ -86,13 +86,13 @@ class DsrTargetControllerSpec extends DsrIntegrationTests {
 		
 		when:
 		dsrTargetController.params.code = CODE(3)
-		dsrTargetController.params['calculationElement.id'] = rawDataElement.id+""
+		dsrTargetController.params['data.id'] = rawDataElement.id+""
 		dsrTargetController.params['program.id'] = program.id+""
 		dsrTargetController.saveWithoutTokenCheck()
 		
 		then:
 		DsrTarget.count() == 1
-		DsrTarget.list()[0].calculationElement.equals(rawDataElement)				
+		DsrTarget.list()[0].data.equals(rawDataElement)				
 	}
 	
 	def "create target with normalized data element calculation element"() {
@@ -106,13 +106,13 @@ class DsrTargetControllerSpec extends DsrIntegrationTests {
 		
 		when:
 		dsrTargetController.params.code = CODE(5)
-		dsrTargetController.params['calculationElement.id'] = normalizedDataElement.id+""
+		dsrTargetController.params['data.id'] = normalizedDataElement.id+""
 		dsrTargetController.params['program.id'] = program.id+""
 		dsrTargetController.saveWithoutTokenCheck()
 		
 		then:
 		DsrTarget.count() == 1
-		DsrTarget.list()[0].calculationElement.equals(normalizedDataElement)
+		DsrTarget.list()[0].data.equals(normalizedDataElement)
 	}
 	
 	def "delete target" () {

--- a/test/integration/org/chai/kevin/dsr/DsrTargetSpec.groovy
+++ b/test/integration/org/chai/kevin/dsr/DsrTargetSpec.groovy
@@ -9,10 +9,10 @@ class DsrTargetSpec extends DsrIntegrationTests {
 	def "can save target"() {
 		setup:
 		def program = newReportProgram(CODE(1))
-		def calculationElement = newRawDataElement(CODE(1), Type.TYPE_NUMBER())
+		def data = newRawDataElement(CODE(1), Type.TYPE_NUMBER())
 		
 		when:
-		new DsrTarget(program: program, code: CODE(1), calculationElement: calculationElement).save(failOnError: true)
+		new DsrTarget(program: program, code: CODE(1), data: data).save(failOnError: true)
 		
 		then:
 		DsrTarget.count() == 1
@@ -32,10 +32,10 @@ class DsrTargetSpec extends DsrIntegrationTests {
 	def "cannot save target with null code"() {
 		setup:
 		def program = newReportProgram(CODE(1))
-		def calculationElement = newRawDataElement(CODE(1), Type.TYPE_NUMBER())
+		def data = newRawDataElement(CODE(1), Type.TYPE_NUMBER())
 		
 		when:
-		new DsrTarget(program: program, calculationElement: calculationElement).save(failOnError: true)
+		new DsrTarget(program: program, data: data).save(failOnError: true)
 		
 		then:
 		thrown ValidationException

--- a/test/integration/org/chai/kevin/dsr/DsrTargetSpec.groovy
+++ b/test/integration/org/chai/kevin/dsr/DsrTargetSpec.groovy
@@ -9,16 +9,16 @@ class DsrTargetSpec extends DsrIntegrationTests {
 	def "can save target"() {
 		setup:
 		def program = newReportProgram(CODE(1))
-		def dataElement = newRawDataElement(CODE(1), Type.TYPE_NUMBER())
+		def calculationElement = newRawDataElement(CODE(1), Type.TYPE_NUMBER())
 		
 		when:
-		new DsrTarget(program: program, code: CODE(1), dataElement: dataElement).save(failOnError: true)
+		new DsrTarget(program: program, code: CODE(1), calculationElement: calculationElement).save(failOnError: true)
 		
 		then:
 		DsrTarget.count() == 1
 	}
 	
-	def "cannot save target with null data element"() {
+	def "cannot save target with null calculation element"() {
 		setup:
 		def program = newReportProgram(CODE(1))
 		
@@ -32,10 +32,10 @@ class DsrTargetSpec extends DsrIntegrationTests {
 	def "cannot save target with null code"() {
 		setup:
 		def program = newReportProgram(CODE(1))
-		def dataElement = newRawDataElement(CODE(1), Type.TYPE_NUMBER())
+		def calculationElement = newRawDataElement(CODE(1), Type.TYPE_NUMBER())
 		
 		when:
-		new DsrTarget(program: program, dataElement: dataElement).save(failOnError: true)
+		new DsrTarget(program: program, calculationElement: calculationElement).save(failOnError: true)
 		
 		then:
 		thrown ValidationException


### PR DESCRIPTION
-dsr target can be created with either a calculation or data element
-dsr report can use either a calculation or data element for report data
-if calculation, the target will display data for all locations
-if data element, the target will only display data for data locations
-dsr target 'dataElement' renamed to 'data', so the db table column name needs to be updated
